### PR TITLE
add OBJC/OBJCXX on Apple Platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 project(aurora LANGUAGES C CXX)
+if(APPLE)
+    enable_language(OBJC OBJCXX)
+endif()
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
 


### PR DESCRIPTION
was seeing this error:
```-- aurora: Building xxhash
-- xxHash build type: Debug
-- Architecture: arm64
-- aurora: Building fmt
-- {fmt} version: 11.1.4
-- Build type: Debug
-- aurora: Building imgui
-- Configuring done (3.5s)
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_OBJC_COMPILE_OBJECT
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_OBJC_COMPILE_OBJECT
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_OBJC_COMPILE_OBJECT
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_OBJC_COMPILE_OBJECT
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_OBJC_COMPILE_OBJECT
-- Generating done (1.2s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

on 
```ProductName:		macOS
ProductVersion:		26.2
BuildVersion:		25C56
```

adding this change to the CMakeLists.txt fixes the build for me.