### PR TITLE
Add stdint.h include for fixed-width integer types

### DIFF
--- a/lib/dolphin/mtx/mtxstack.c
+++ b/lib/dolphin/mtx/mtxstack.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdint.h>
 #include <dolphin/mtx.h>
 
 void MTXInitStack(MTXStack* sPtr, u32 numMtx) {


### PR DESCRIPTION
was failing to build on mac, missing intptr_t