### PR TITLE
move assert in TryGuardRegion to in w32 only code

### DIFF
--- a/lib/dolphin/os/OSMemory.cpp
+++ b/lib/dolphin/os/OSMemory.cpp
@@ -48,9 +48,8 @@ static uintptr_t GetAllocationGranularity() {
 }
 
 static void TryGuardRegion(const uintptr_t start, const uintptr_t end, char const* const name) {
-  assert(start != 0);
-
 #if _WIN32
+  assert(start != 0);
   const auto addr = VirtualAlloc(
       reinterpret_cast<LPVOID>(start),
       end - start,


### PR DESCRIPTION
this will always fire on posix platforms unless the rest other calls to this part of the code are implemented (which they probably won't be)