### PR TITLE
Fix display list check for correct namespace

### DIFF
--- a/lib/dolphin/gx/GXDispList.cpp
+++ b/lib/dolphin/gx/GXDispList.cpp
@@ -10,7 +10,7 @@ static __GXData_struct sSavedGXData;
 
 extern "C" {
 void GXBeginDisplayList(void* list, u32 size) {
-  CHECK(!aurora::gfx::fifo::in_display_list(), "Display list began twice!");
+  CHECK(!aurora::gx::fifo::in_display_list(), "Display list began twice!");
 
   // Flush any pending dirty state before recording
   if (__gx->dirtyState != 0) {


### PR DESCRIPTION
```
/Users/jeff/dev/games/dusk/extern/aurora/lib/dolphin/gx/GXDispList.cpp:13:10: error: no member named 'fifo' in namespace 'aurora::gfx'; did you mean 'aurora::gx::fifo'?
   13 |   CHECK(!aurora::gfx::fifo::in_display_list(), "Display list began twice!");
      |          ^~~~~~~~~~~~~~~~~
      |          aurora::gx::fifo
```

I assume this is what you meant?