### PR TITLE
Correct pipeline cache path mismatch

### DIFF
--- a/lib/gfx/common.cpp
+++ b/lib/gfx/common.cpp
@@ -353,7 +353,7 @@ void load_pipeline_cache() {
 
 // Write serialized pipelines to file
 void save_pipeline_cache() {
-  const auto path = std::string{g_config.configPath} + "pipeline_cache.bin";
+  const auto path = std::string{g_config.configPath} + "/pipeline_cache.bin";
   std::ofstream file(path, std::ios::out | std::ios::trunc | std::ios::binary);
   if (file) {
     file.write(reinterpret_cast<const char*>(&g_serializedPipelineCount), sizeof(g_serializedPipelineCount));


### PR DESCRIPTION
enables pipeline caching for recomps using aurora; they were being saved to `.pipeline_cache.bin` rather than `pipeline_cache.bin`, while the loader was looking for `pipeline_cache.bin`