### PR TITLE
make absl always come from aurora deps and not system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,15 +52,6 @@ set_property(CACHE AURORA_NOD_LINKAGE PROPERTY STRINGS shared static)
 
 add_subdirectory(extern)
 
-# Ensure Abseil headers come from Aurora's configured dependency target
-if (TARGET absl::flat_hash_map)
-  get_target_property(_aurora_absl_include_dirs absl::flat_hash_map INTERFACE_INCLUDE_DIRECTORIES)
-  if (_aurora_absl_include_dirs)
-    include_directories(BEFORE ${_aurora_absl_include_dirs})
-  endif ()
-  unset(_aurora_absl_include_dirs)
-endif ()
-
 include(cmake/aurora_core.cmake)
 include(cmake/aurora_os.cmake)
 if (AURORA_ENABLE_GX)


### PR DESCRIPTION
I'm not sure if this is the best way to do it, I assume this should probably be generalized for all of the deps we pull? but this is just a start to make sure things will work/build