### PR TITLE
avoid redundant storage uploads and extra alignment padding

### DIFF
--- a/lib/gfx/common.cpp
+++ b/lib/gfx/common.cpp
@@ -715,7 +715,10 @@ bool bind_pipeline(PipelineRef ref, const wgpu::RenderPassEncoder& pass) {
 static inline Range push(ByteBuffer& target, const uint8_t* data, size_t length, size_t alignment) {
   size_t padding = 0;
   if (alignment != 0) {
-    padding = alignment - length % alignment;
+    const size_t remainder = length % alignment;
+    if (remainder != 0) {
+      padding = alignment - remainder;
+    }
   }
   auto begin = target.size();
   if (length == 0) {
@@ -732,7 +735,10 @@ static inline Range push(ByteBuffer& target, const uint8_t* data, size_t length,
 static inline Range map(ByteBuffer& target, size_t length, size_t alignment) {
   size_t padding = 0;
   if (alignment != 0) {
-    padding = alignment - length % alignment;
+    const size_t remainder = length % alignment;
+    if (remainder != 0) {
+      padding = alignment - remainder;
+    }
   }
   if (length == 0) {
     length = alignment;

--- a/lib/gx/command_processor.cpp
+++ b/lib/gx/command_processor.cpp
@@ -1342,9 +1342,12 @@ static void handle_cp(u8 addr, u32 value, bool bigEndian) {
     else if (addr >= 0xB0 && addr <= 0xBF) {
       u32 attrIdx = addr - 0xB0 + GX_VA_POS;
       if (attrIdx < GX_VA_MAX_ATTR) {
-        g_gxState.arrays[attrIdx].stride = static_cast<u8>(value);
-        g_gxState.arrays[attrIdx].cachedRange = {};
-        g_gxState.stateDirty = true;
+        auto& array = g_gxState.arrays[attrIdx];
+        const auto newStride = static_cast<u8>(value);
+        if (array.stride != newStride) {
+          array.stride = newStride;
+          g_gxState.stateDirty = true;
+        }
       }
     }
     break;
@@ -1718,10 +1721,16 @@ void handle_aurora(const u8* data, u32& pos, u32 size, bool bigEndian) {
 
     CHECK(arraySize <= std::numeric_limits<decltype(g_gxState.arrays[attrIdx].size)>::max(), "Array size too large!");
 
-    g_gxState.arrays[attrIdx].data = reinterpret_cast<void*>(arrayAddr);
-    g_gxState.arrays[attrIdx].size = (u32)arraySize;
-    g_gxState.arrays[attrIdx].cachedRange = {};
-    g_gxState.stateDirty = true;
+    auto& array = g_gxState.arrays[attrIdx];
+    const auto newData = reinterpret_cast<void*>(arrayAddr);
+    const auto newSize = static_cast<u32>(arraySize);
+    if (array.data != newData || array.size != newSize) {
+      array.data = newData;
+      array.size = newSize;
+      // Only drop the cached upload when the backing array actually changes.
+      array.cachedRange = {};
+      g_gxState.stateDirty = true;
+    }
   } else if (subCmd == GX_LOAD_AURORA_DEBUG_GROUP_PUSH) {
     auto label = read_string(data, pos, size, bigEndian);
     gfx::push_debug_group(std::move(label));


### PR DESCRIPTION
was hitting this crash:

```
  (lldb) bt
  * thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    * frame #0: 0x00000001927915b0 libsystem_kernel.dylib`__pthread_kill + 8 frame #1: 0x00000001927cb888 libsystem_pthread.dylib`pthread_kill + 296 frame #2: 0x00000001926d0850 libsystem_c.dylib`abort + 124 frame #3: 0x00000001060400f8 libgame.dylib`aurora::ByteBuffer::resize(this=0x0000000106b97358, size=8488606, zeroed=false) at common.hpp:141:9 frame #4: 0x0000000106047cb8 libgame.dylib`aurora::ByteBuffer::append(this=0x0000000106b97358, data=0x00000004323e0ae0, size=145566) at common.hpp:96:5 frame #5: 0x0000000106038230 libgame.dylib`aurora::gfx::push(target=0x0000000106b97358, data="b0\xf2", length=145566, alignment=256) at common.cpp:725:12 frame #6: 0x0000000106038340 libgame.dylib`aurora::gfx::push_storage(data="b0\xf2", length=145566) at common.cpp:750:10 frame #7: 0x000000010606c144 libgame.dylib`aurora::gx::fifo::handle_draw(cmd=152 '\x98', data="\x98", pos=0x000000016d931eac, size=1184, bigEndian=true) at command_processor.cpp:1668:26 frame #8: 0x0000000106066434 libgame.dylib`aurora::gx::fifo::process(data="\x98", size=1184, bigEndian=true) at command_processor.cpp:628:7 frame #9: 0x00000001060a00dc libgame.dylib`GXCallDisplayList(data=0x000000043247f980, nbytes=1184) at GXDispList.cpp:67:3 frame #10: 0x0000000105f7d440 libgame.dylib`J3DShapeDraw::draw(this=0x0000000432839a28) const at J3DShapeDraw.cpp:79:5 frame #11: 0x0000000105f7e97c libgame.dylib`J3DShape::drawFast(this=0x0000000432839960) const at J3DShape.cpp:337:32 frame #12: 0x0000000105f793a0 libgame.dylib`J3DShapePacket::drawFast(this=0x00000004329be9e8) at J3DPacket.cpp:401:18 frame #13: 0x0000000105f79280 libgame.dylib`J3DMatPacket::draw(this=0x00000004329bf448) at J3DPacket.cpp:236:17 frame #14: 0x0000000105f98b3c libgame.dylib`J3DDrawBuffer::drawHead(this=0x000000042f513808) const at J3DDrawBuffer.cpp:232:21 frame #15: 0x0000000105f98ce8 libgame.dylib`J3DDrawBuffer::draw(this=0x000000042f513808) const at J3DDrawBuffer.cpp:223:5 frame #16: 0x000000010530cd50 libgame.dylib`dDlst_list_c::drawXluDrawList(this=0x0000000106bb99d0, pDrawBuf=0x000000042f513808) at d_drawlist.cpp:1835:15 frame #17: 0x000000010528bc10 libgame.dylib`dDlst_list_c::drawXluListDarkBG(this=0x0000000106bb99d0) at d_drawlist.h:479:32 frame #18: 0x0000000105289150 libgame.dylib`dComIfGd_drawXluListDarkBG() at d_com_inf_game.h:4729:33 frame #19: 0x0000000105287dc0 libgame.dylib`mDoGph_Painter() at m_Do_graphic.cpp:1783:13 frame #20: 0x00000001056325f0 libgame.dylib`cAPIGph_Painter() at c_API_graphic.cpp:10:5 frame #21: 0x00000001052b6560 libgame.dylib`fpcM_Management(i_preExecuteFn=0x0000000000000000, i_postExecuteFn=(libgame.dylib`fapGm_After() at f_ap_game.cpp:718)) at f_pc_manager.cpp:64:13 frame #22: 0x00000001052a5fa8 libgame.dylib`fapGm_Execute() at f_ap_game.cpp:735:5 frame #23: 0x0000000105236db0 libgame.dylib`main01() at m_Do_main.cpp:177:9 frame #24: 0x0000000105237e2c libgame.dylib`game_main(argc=1, argv=0x000000016d9335a0) at m_Do_main.cpp:298:5 frame #25: 0x00000001024cd518 dusk`main(argc=1, argv=0x000000016d9335a0) at main.cpp:12:12 frame #26: 0x0000000192401d54 dyld`start + 7184

  (lldb) f 4
  frame #4: 0x0000000106047cb8 libgame.dylib`aurora::ByteBuffer::append(this=0x0000000106b97358, data=0x00000004323e0ae0, size=145566) at common.hpp:96:5
     93  	  [[nodiscard]] bool empty() const noexcept { return m_length == 0; }
     94
     95  	  void append(const void* data, size_t size) {
  -> 96  	    resize(m_length + size, false);
      	    ^
     97  	    memcpy(m_data + m_length, data, size);
     98  	    m_length += size;
     99  	  }

› (lldb) p/x m_capacity
  (size_t) 0x0000000000800000
  (lldb) p m_capacity
  (size_t) 8388608
  (lldb) p/x size
  (size_t) 0x000000000081869e these were the size/capacity
```
essentially alignment padding was making the capacity overwhelmed.