### PR TITLE
Add compiler attributes to formatting functions

### DIFF
--- a/include/dolphin/os.h
+++ b/include/dolphin/os.h
@@ -212,9 +212,9 @@ BOOL OSRestoreInterrupts(BOOL level);
 u32 OSGetSoundMode(void);
 void OSSetSoundMode(u32 mode);
 
-DECL_WEAK void OSReport(const char* msg, ...);
-DECL_WEAK void OSVReport(const char* msg, va_list list);
-DECL_WEAK void OSPanic NORETURN(const char* file, int line, const char* msg, ...);
+DECL_WEAK void OSReport(FORMAT_STRING_PARAM const char* msg, ...) FORMAT_STRING_FUNC(printf, 1, 2);
+DECL_WEAK void OSVReport(FORMAT_STRING_PARAM const char* msg, va_list list) FORMAT_STRING_FUNC(printf, 1, 2);
+DECL_WEAK void OSPanic NORETURN(const char* file, int line, FORMAT_STRING_PARAM const char* msg, ...) FORMAT_STRING_FUNC(printf, 3, 4);
 void OSFatal NORETURN(GXColor fg, GXColor bg, const char* msg);
 
 #define OSRoundUp32B(x)   (((uintptr_t)(x) + 32 - 1) & ~(32 - 1))

--- a/include/dolphin/types.h
+++ b/include/dolphin/types.h
@@ -107,4 +107,17 @@ typedef int BOOL;
 #define __REGISTER
 #endif
 
+#ifdef _MSC_VER
+#include <sal.h>
+#define FORMAT_STRING_PARAM _Printf_format_string_
+#else
+#define FORMAT_STRING_PARAM
+#endif
+
+#if defined(__GNUC__)
+#define FORMAT_STRING_FUNC(type, string_index, first_to_check) __attribute__((format(type, string_index, first_to_check)))
+#else
+#define FORMAT_STRING_FUNC(type, string_index, first_to_check)
+#endif
+
 #endif


### PR DESCRIPTION
OSReport, OSVReport, OSPanic

I hoped these would show up in my IDE but sadly not. Still, I figure there's no harm in it?