### PR TITLE
support Apple libc++ for OSGetTime

### DIFF
--- a/lib/dolphin/os/OSTime.cpp
+++ b/lib/dolphin/os/OSTime.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <ctime>
 
 #include "internal.hpp"
 #include <dolphin/os.h>
@@ -8,10 +9,44 @@ static const int YearDays[MONTH_MAX] = {0, 31, 59, 90, 120, 151, 181, 212, 243, 
 static const int LeapYearDays[MONTH_MAX] = {0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335};
 
 namespace chrono = std::chrono;
+using SystemDuration = chrono::system_clock::duration;
+using SystemTime = chrono::time_point<chrono::system_clock>;
+using LocalTime = chrono::local_time<SystemDuration>;
 using TickDuration = chrono::duration<s64, std::ratio<1, OS_TIMER_CLOCK>>;
 
-static chrono::time_point<chrono::system_clock> startupTime = chrono::system_clock::now();
-static chrono::time_point<chrono::steady_clock> startupSteadyTime = chrono::steady_clock::now();
+static const SystemTime startupTime = chrono::system_clock::now();
+static const chrono::time_point<chrono::steady_clock> startupSteadyTime = chrono::steady_clock::now();
+
+static LocalTime SystemTimeToLocalTime(SystemTime time) {
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+    return chrono::zoned_time(chrono::current_zone(), time).get_local_time();
+#else
+    // Apple libc++ currently ships <chrono> with the C++20 timezone database API disabled
+    // (_LIBCPP_HAS_TIME_ZONE_DATABASE == 0), so zoned_time/current_zone are unavailable there.
+    const auto wholeSeconds = chrono::floor<chrono::seconds>(time);
+    const auto fractionalSeconds = chrono::duration_cast<SystemDuration>(time - wholeSeconds);
+    std::time_t wallClock = chrono::system_clock::to_time_t(wholeSeconds);
+    std::tm localTm{};
+
+#if defined(_WIN32)
+    ASSERT(localtime_s(&localTm, &wallClock) == 0);
+#else
+    ASSERT(localtime_r(&wallClock, &localTm) != nullptr);
+#endif
+
+    const auto localDate = chrono::local_days{
+        chrono::year{localTm.tm_year + 1900} / chrono::month{static_cast<unsigned>(localTm.tm_mon + 1)} /
+        chrono::day{static_cast<unsigned>(localTm.tm_mday)}};
+    const auto localTimeOfDay =
+        chrono::hours{localTm.tm_hour} + chrono::minutes{localTm.tm_min} + chrono::seconds{localTm.tm_sec};
+    return LocalTime{
+        chrono::duration_cast<SystemDuration>(localDate.time_since_epoch()) +
+        chrono::duration_cast<SystemDuration>(localTimeOfDay) +
+        fractionalSeconds};
+#endif
+}
+
+static const LocalTime startupLocalTime = SystemTimeToLocalTime(startupTime);
 
 OSTick OSGetTick() {
     return OSGetTime() & 0xFFFFFFFF;
@@ -24,9 +59,9 @@ OSTime OSGetTime() {
 
     static const auto gcnEpoch = chrono::local_days{chrono::year{2000} / chrono::January / 1};
 
-    auto startupOffset = chrono::steady_clock::now() - startupSteadyTime;
-    auto nowTime = chrono::zoned_time(std::chrono::current_zone(), startupTime + startupOffset).get_local_time();
-    auto clockTime = nowTime - gcnEpoch;
+    auto elapsedSinceStartup = chrono::duration_cast<SystemDuration>(chrono::steady_clock::now() - startupSteadyTime);
+    auto currentLocalTime = startupLocalTime + elapsedSinceStartup;
+    auto clockTime = currentLocalTime - gcnEpoch;
 
     // The current time is around the order of 1e17 ns, which is about 1/22 of INT64_MAX. The
     // effective ratio of ticks/nanoseconds is 81/200, which means if we try to convert directly


### PR DESCRIPTION
Apple libc++ currently ships <chrono> with the C++20 timezone database API disabled so zoned_time/current_zone are unavailable there.