### PR TITLE
fix incorrect t_TexCoord usage

### DIFF
--- a/lib/gx/shader.cpp
+++ b/lib/gx/shader.cpp
@@ -1377,7 +1377,7 @@ wgpu::ShaderModule build_shader(const ShaderConfig& config, const ShaderInfo& in
         finalCoord = indirectOffsetTexel;
       }
 
-      if (!finalCoord.empty()) {
+      if (info.usedIndStages.any() && !finalCoord.empty()) {
         if (stage.indTexAddPrev) {
           fragmentFnPre += fmt::format("\n    t_TexCoord += {};", finalCoord);
         } else {


### PR DESCRIPTION
fixes error about `[FATAL | aurora::gpu] WebGPU error 2: Error while parsing WGSL: :358:5 error: unresolved value 't_TexCoord' t_TexCoord = ind0_texel;`