### PR TITLE
Add GX_TF_AURORA_I8_LINEAR format

### DIFF
--- a/include/dolphin/gx/GXEnum.h
+++ b/include/dolphin/gx/GXEnum.h
@@ -132,6 +132,8 @@ typedef enum {
 #define _GX_TF_CTF 0x20
 #define _GX_TF_ZTF 0x10
 
+#define _GX_TF_AURORA_LINEAR 0x40
+
 typedef enum {
   GX_TF_I4 = 0x0,
   GX_TF_I8 = 0x1,
@@ -163,6 +165,8 @@ typedef enum {
   GX_CTF_Z16L = 0xC | _GX_TF_ZTF | _GX_TF_CTF,
 
   GX_TF_A8 = GX_CTF_A8,
+
+  GX_TF_AURORA_I8_LINEAR = _GX_TF_AURORA_LINEAR | GX_TF_IA8,
 } GXTexFmt;
 
 typedef enum {

--- a/lib/gfx/texture.cpp
+++ b/lib/gfx/texture.cpp
@@ -109,6 +109,7 @@ TextureHandle new_static_texture_2d(uint32_t width, uint32_t height, uint32_t mi
 static bool setup_swizzle(wgpu::TextureComponentSwizzleDescriptor & swizzle, u32 format) {
   switch (format) {
   case GX_TF_I4:
+  case GX_TF_AURORA_I8_LINEAR:
   case GX_TF_I8:
     swizzle.swizzle.r = wgpu::ComponentSwizzle::R;
     swizzle.swizzle.g = wgpu::ComponentSwizzle::R;

--- a/lib/gfx/texture_convert.cpp
+++ b/lib/gfx/texture_convert.cpp
@@ -118,6 +118,35 @@ static ByteBuffer DecodeTiled(uint32_t width, uint32_t height, uint32_t mips, Ar
 }
 
 template <TextureDecoder T>
+static ByteBuffer Decode2DLinear(uint32_t width, uint32_t height, uint32_t mips, ArrayRef<uint8_t> data) {
+  const size_t texelCount = ComputeMippedTexelCount(width, height, mips);
+  ByteBuffer buf{texelCount * sizeof(typename T::Target)};
+
+  uint32_t w = width;
+  uint32_t h = height;
+  auto* targetMip = reinterpret_cast<typename T::Target*>(buf.data());
+  const auto* in = reinterpret_cast<const typename T::Source*>(data.data());
+  for (uint32_t mip = 0; mip < mips; ++mip) {
+    for (uint32_t y = 0; y < h; ++y) {
+      for (uint32_t x = 0; x < w; ++x) {
+        auto* target = targetMip + y * w + x;
+        T::decode_texel(target, in, 0);
+        in += sizeof(typename T::Target);
+      }
+    }
+    targetMip += w * h;
+    if (w > 1) {
+      w /= 2;
+    }
+    if (h > 1) {
+      h /= 2;
+    }
+  }
+
+  return buf;
+}
+
+template <TextureDecoder T>
 static ByteBuffer DecodeLinear(uint32_t width, ArrayRef<uint8_t> data) {
   ByteBuffer buf{width * sizeof(typename T::Target)};
   auto* target = reinterpret_cast<typename T::Target*>(buf.data());
@@ -434,6 +463,8 @@ ByteBuffer convert_texture(u32 format, uint32_t width, uint32_t height, uint32_t
     return {}; // No conversion
   case GX_TF_I4:
     return DecodeTiled<TextureDecoderI4>(width, height, mips, data);
+  case GX_TF_AURORA_I8_LINEAR:
+    return Decode2DLinear<TextureDecoderI8>(width, height, mips, data);
   case GX_TF_I8:
     return DecodeTiled<TextureDecoderI8>(width, height, mips, data);
   case GX_TF_IA4:

--- a/lib/gfx/texture_convert.hpp
+++ b/lib/gfx/texture_convert.hpp
@@ -9,6 +9,7 @@ static wgpu::TextureFormat to_wgpu(u32 format) {
   switch (format) {
   case GX_TF_I4:
   case GX_TF_I8:
+  case GX_TF_AURORA_I8_LINEAR:
   case GX_TF_R8_PC:
     return wgpu::TextureFormat::R8Unorm;
   case GX_TF_C4:

--- a/lib/gx/gx.hpp
+++ b/lib/gx/gx.hpp
@@ -362,6 +362,7 @@ static inline bool requires_load_conversion(const GXTexObj_& obj) {
   switch (obj.fmt) {
   case GX_TF_I4:
   case GX_TF_I8:
+  case GX_TF_AURORA_I8_LINEAR:
   case GX_TF_C4:
   case GX_TF_C8:
   case GX_TF_C14X2:

--- a/lib/gx/shader.cpp
+++ b/lib/gx/shader.cpp
@@ -484,6 +484,7 @@ static inline std::string texture_conversion(const TextureConfig& tex, u32 stage
       out += fmt::format("\n    sampled{0}.a = 1.0;", stageIdx);
       break;
     case GX_TF_I4:
+    case GX_TF_AURORA_I8_LINEAR:
     case GX_TF_I8:
       // FIXME HACK
       if (!is_palette_format(tex.loadFmt)) {
@@ -496,6 +497,7 @@ static inline std::string texture_conversion(const TextureConfig& tex, u32 stage
   default:
     break;
   case GX_TF_I4:
+  case GX_TF_AURORA_I8_LINEAR:
   case GX_TF_I8:
   case GX_TF_R8_PC:
     // Splat R to RGBA


### PR DESCRIPTION
When decoding THP video frames in a custom manner, libjpeg or whatever isn't gonna give us image data in the same tiled format the GameCube expects. So instead of re-tiling it (only for Aurora to un-tile it), let's just allow Aurora to read the linear data directly.

This adds a new texture format, GX_TF_AURORA_I8_LINEAR, which is interpreted in a simple 2D linear layout.

Another possible implementation is a separate flag somewhere, but I wasn't sure what the best way to go about that would be.