### PR TITLE
Fix PAD stick range

### DIFF
--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -375,8 +375,8 @@ void ClampStick(int8_t* px, int8_t* py, int8_t max, int8_t xy, int8_t min) {
     return;
   }
 
-  x = (x * max) / (127 - min);
-  y = (y * max) / (127 - min);
+  x = (x * max) / (INT8_MAX - min);
+  y = (y * max) / (INT8_MAX - min);
 
   if (xy * y <= xy * x) {
     int32_t d = xy * x + (max - xy) * y;


### PR DESCRIPTION
In the port project which shall not be named, sticks would act like they were fully tilted long before the stick was actually physically at full tilt. I was able to reproduce this behavior on Xbox Series X, Xbox One, and DualSense controllers.

Scaling the range after the deadzone math brings Aurora inline with Dolphin Emulator's behavior, in so far as I can perceive visually anyways.

Probably shouldn't be merged until more ports (I.E. Metaforce) and more controllers are tested to ensure this doesn't cause regressions.