### PR TITLE
Add functionality to lock GX framebuffer aspect ratio

### DIFF
--- a/include/aurora/aurora.h
+++ b/include/aurora/aurora.h
@@ -40,8 +40,28 @@ typedef struct {
 typedef struct {
   uint32_t width;
   uint32_t height;
+
+  /**
+   * Width of the main GX framebuffer.
+   */
   uint32_t fb_width;
+
+  /**
+   * Height of the main GX framebuffer.
+   */
   uint32_t fb_height;
+
+  /**
+   * The size of the framebuffer used to present to the operating system.
+   * May differ from fb_width if Aurora is instructed to force an aspect ratio or resolution configuration.
+   */
+  uint32_t native_fb_width;
+
+  /**
+   * The size of the framebuffer used to present to the operating system.
+   * May differ from fb_height if Aurora is instructed to force an aspect ratio or resolution configuration.
+   */
+  uint32_t native_fb_height;
   float scale;
 } AuroraWindowSize;
 

--- a/include/dolphin/vi.h
+++ b/include/dolphin/vi.h
@@ -35,6 +35,19 @@ VIRetraceCallback VISetPostRetraceCallback(VIRetraceCallback cb);
 void VISetWindowTitle(const char* title);
 void VISetWindowFullscreen(bool fullscreen);
 bool VIGetWindowFullscreen();
+
+/**
+ * \brief Lock the GX framebuffer to a specific aspect ratio, without changing the native framebuffer.
+ *
+ * @param width Width part of the aspect ratio fraction.
+ * @param height Height part of the aspect ratio fraction.
+ */
+void VILockAspectRatio(int width, int height);
+
+/**
+ * \brief Undoes a previous call to VILockAspectRatio.
+ */
+void VIUnlockAspectRatio();
 #endif
 
 #ifdef __cplusplus

--- a/lib/aurora.cpp
+++ b/lib/aurora.cpp
@@ -233,6 +233,15 @@ void end_frame() noexcept {
     // Copy EFB -> XFB (swapchain)
     pass.SetPipeline(webgpu::g_CopyPipeline);
     pass.SetBindGroup(0, webgpu::g_CopyBindGroup, 0, nullptr);
+
+    // Center viewport to framebuffer size in case we're at an aspect ratio lock.
+    {
+      uint32_t pos_x = (webgpu::g_graphicsConfig.surfaceConfiguration.width - webgpu::g_frameBuffer.size.width) / 2;
+      uint32_t pos_y = (webgpu::g_graphicsConfig.surfaceConfiguration.height - webgpu::g_frameBuffer.size.height) / 2;
+
+      pass.SetViewport(pos_x, pos_y, webgpu::g_frameBuffer.size.width, webgpu::g_frameBuffer.size.height, 0, 1);
+    }
+
     pass.Draw(3);
     imgui::render(pass);
     pass.End();

--- a/lib/dolphin/vi/vi.cpp
+++ b/lib/dolphin/vi/vi.cpp
@@ -10,4 +10,6 @@ void VIFlush() {}
 void VISetWindowTitle(const char* title) { aurora::window::set_title(title); }
 void VISetWindowFullscreen(bool fullscreen) { aurora::window::set_fullscreen(fullscreen); }
 bool VIGetWindowFullscreen() { return aurora::window::get_fullscreen(); }
+void VILockAspectRatio(int width, int height) { return aurora::window::lock_aspect_ratio(width, height); }
+void VIUnlockAspectRatio() { return aurora::window::unlock_aspect_ratio(); }
 }

--- a/lib/imgui.cpp
+++ b/lib/imgui.cpp
@@ -95,8 +95,8 @@ void new_frame(const AuroraWindowSize& size) noexcept {
 
   // Render at full DPI
   ImGui::GetIO().DisplaySize = {
-      static_cast<float>(size.fb_width),
-      static_cast<float>(size.fb_height),
+      static_cast<float>(size.native_fb_width),
+      static_cast<float>(size.native_fb_height),
   };
   ImGui::NewFrame();
 }

--- a/lib/imgui.cpp
+++ b/lib/imgui.cpp
@@ -70,9 +70,9 @@ void process_event(const SDL_Event& event) noexcept {
 
 void new_frame(const AuroraWindowSize& size) noexcept {
   const float framebufferScaleX =
-      size.width > 0 ? static_cast<float>(size.fb_width) / static_cast<float>(size.width) : 1.0f;
+      size.width > 0 ? static_cast<float>(size.native_fb_width) / static_cast<float>(size.width) : 1.0f;
   const float framebufferScaleY =
-      size.height > 0 ? static_cast<float>(size.fb_height) / static_cast<float>(size.height) : 1.0f;
+      size.height > 0 ? static_cast<float>(size.native_fb_height) / static_cast<float>(size.height) : 1.0f;
 
   if (g_useSdlRenderer) {
     ImGui_ImplSDLRenderer3_NewFrame();

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -47,10 +47,10 @@ static wgpu::Adapter g_adapter;
 wgpu::Instance g_instance;
 static wgpu::AdapterInfo g_adapterInfo;
 
-TextureWithSampler create_render_texture(bool multisampled) {
+TextureWithSampler create_render_texture(uint32_t width, uint32_t height, bool multisampled) {
   const wgpu::Extent3D size{
-      .width = g_graphicsConfig.surfaceConfiguration.width,
-      .height = g_graphicsConfig.surfaceConfiguration.height,
+      .width = width,
+      .height = height,
       .depthOrArrayLayers = 1,
   };
   const auto format = g_graphicsConfig.surfaceConfiguration.format;
@@ -99,10 +99,10 @@ TextureWithSampler create_render_texture(bool multisampled) {
   };
 }
 
-static TextureWithSampler create_depth_texture() {
+static TextureWithSampler create_depth_texture(uint32_t width, uint32_t height) {
   const wgpu::Extent3D size{
-      .width = g_graphicsConfig.surfaceConfiguration.width,
-      .height = g_graphicsConfig.surfaceConfiguration.height,
+      .width = width,
+      .height = height,
       .depthOrArrayLayers = 1,
   };
   const auto format = g_graphicsConfig.depthFormat;
@@ -549,8 +549,8 @@ bool initialize(AuroraBackend auroraBackend) {
           wgpu::SurfaceConfiguration{
               .format = surfaceFormat,
               .usage = wgpu::TextureUsage::RenderAttachment,
-              .width = size.fb_width,
-              .height = size.fb_height,
+              .width = size.native_fb_width,
+              .height = size.native_fb_height,
               .presentMode = presentMode,
           },
       .depthFormat = wgpu::TextureFormat::Depth32Float,
@@ -558,7 +558,7 @@ bool initialize(AuroraBackend auroraBackend) {
       .textureAnisotropy = g_config.maxTextureAnisotropy,
   };
   create_copy_pipeline();
-  resize_swapchain(size.fb_width, size.fb_height, true);
+  resize_swapchain(size.fb_width, size.fb_height, size.native_fb_width, size.native_fb_width, true);
   return true;
 }
 
@@ -585,23 +585,28 @@ bool refresh_surface(bool recreate) {
   }
   uint32_t width = g_graphicsConfig.surfaceConfiguration.width;
   uint32_t height = g_graphicsConfig.surfaceConfiguration.height;
+  uint32_t native_width = width;
+  uint32_t native_height = height;
   if (window::get_sdl_window() != nullptr) {
     const auto size = window::get_window_size();
     width = size.fb_width;
     height = size.fb_height;
+    native_width = size.native_fb_width;
+    native_height = size.native_fb_height;
   }
   if (width != 0 && height != 0) {
-    resize_swapchain(width, height, true);
+    resize_swapchain(width, height, native_width, native_height, true);
   }
   return true;
 }
 
-void resize_swapchain(uint32_t width, uint32_t height, bool force) {
-  if (!g_surface || !g_device || width == 0 || height == 0) {
+void resize_swapchain(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height, bool force) {
+  if (!g_surface || !g_device || width == 0 || height == 0 || native_height == 0 || native_width == 0) {
     return;
   }
-  const bool sizeChanged =
-      g_graphicsConfig.surfaceConfiguration.width != width || g_graphicsConfig.surfaceConfiguration.height != height;
+  const bool sizeChanged = g_graphicsConfig.surfaceConfiguration.width != native_width ||
+                           g_graphicsConfig.surfaceConfiguration.height != native_height ||
+                           g_frameBuffer.size.width != width || g_frameBuffer.size.height != height;
   if (!force && !sizeChanged) {
     return;
   }
@@ -609,14 +614,14 @@ void resize_swapchain(uint32_t width, uint32_t height, bool force) {
     gx::clear_copy_texture_cache();
     gfx::clear_offscreen_cache();
   }
-  g_graphicsConfig.surfaceConfiguration.width = width;
-  g_graphicsConfig.surfaceConfiguration.height = height;
+  g_graphicsConfig.surfaceConfiguration.width = native_width;
+  g_graphicsConfig.surfaceConfiguration.height = native_height;
   auto surfaceConfiguration = g_graphicsConfig.surfaceConfiguration;
   surfaceConfiguration.device = g_device;
   g_surface.Configure(&surfaceConfiguration);
-  g_frameBuffer = create_render_texture(true);
-  g_frameBufferResolved = create_render_texture(false);
-  g_depthBuffer = create_depth_texture();
+  g_frameBuffer = create_render_texture(width, height, true);
+  g_frameBufferResolved = create_render_texture(width, height, false);
+  g_depthBuffer = create_depth_texture(width, height);
   create_copy_bind_group();
 }
 } // namespace aurora::webgpu

--- a/lib/webgpu/gpu.hpp
+++ b/lib/webgpu/gpu.hpp
@@ -40,8 +40,8 @@ extern wgpu::Instance g_instance;
 bool initialize(AuroraBackend backend);
 void shutdown();
 bool refresh_surface(bool recreate = true);
-void resize_swapchain(uint32_t width, uint32_t height, bool force = false);
-TextureWithSampler create_render_texture(bool multisampled);
+void resize_swapchain(uint32_t width, uint32_t height, uint32_t native_width, uint32_t native_height, bool force = false);
+TextureWithSampler create_render_texture(uint32_t width, uint32_t height, bool multisampled);
 void draw_clear(const wgpu::RenderPassEncoder& pass, bool clearColor, bool clearAlpha, bool clearDepth,
                 const Vec4<float>& clearColorValue, float clearDepthValue);
 } // namespace aurora::webgpu

--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -27,14 +27,18 @@ namespace aurora::window {
 namespace {
 Module Log("aurora::window");
 
+uint32_t g_sdlResizeAspectRatioEvent;
 SDL_Window* g_window;
 SDL_Renderer* g_renderer;
+bool g_aspectRatioLocked;
+int g_aspectRatioW, g_aspectRatioH;
 AuroraWindowSize g_windowSize;
 std::vector<AuroraEvent> g_events;
 
 inline bool operator==(const AuroraWindowSize& lhs, const AuroraWindowSize& rhs) {
   return lhs.width == rhs.width && lhs.height == rhs.height && lhs.fb_width == rhs.fb_width &&
-         lhs.fb_height == rhs.fb_height && lhs.scale == rhs.scale;
+         lhs.fb_height == rhs.fb_height && lhs.native_fb_height == rhs.native_fb_height &&
+         lhs.native_fb_width == rhs.native_fb_width && lhs.scale == rhs.scale;
 }
 
 void resize_swapchain() noexcept {
@@ -49,7 +53,7 @@ void resize_swapchain() noexcept {
   }
   g_windowSize = size;
 #ifdef AURORA_ENABLE_GX
-  webgpu::resize_swapchain(size.fb_width, size.fb_height);
+  webgpu::resize_swapchain(size.fb_width, size.fb_height, size.native_fb_width, size.native_fb_height);
 #endif
 }
 
@@ -156,6 +160,13 @@ const AuroraEvent* poll_events() {
           .type = AURORA_EXIT,
       });
     default:
+      if (event.type == g_sdlResizeAspectRatioEvent) {
+        resize_swapchain();
+        g_events.push_back(AuroraEvent{
+            .type = AURORA_WINDOW_RESIZED,
+            .windowSize = get_window_size(),
+        });
+      }
       break;
     }
 
@@ -303,6 +314,10 @@ bool initialize() {
         SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, SDL_GetError());
   }
 
+  TRY(
+    (g_sdlResizeAspectRatioEvent = SDL_RegisterEvents(1)),
+    "Failed to allocate user events: {}", SDL_GetError());
+
   return true;
 }
 
@@ -315,16 +330,32 @@ void shutdown() {
 AuroraWindowSize get_window_size() {
   int width = 0;
   int height = 0;
-  int fb_w = 0;
-  int fb_h = 0;
+  int native_fb_w = 0;
+  int native_fb_h = 0;
   ASSERT(SDL_GetWindowSize(g_window, &width, &height), "Failed to get window size: {}", SDL_GetError());
-  ASSERT(SDL_GetWindowSizeInPixels(g_window, &fb_w, &fb_h), "Failed to get window size in pixels: {}", SDL_GetError());
+  ASSERT(SDL_GetWindowSizeInPixels(g_window, &native_fb_w, &native_fb_h), "Failed to get window size in pixels: {}", SDL_GetError());
+
+  int fb_w = native_fb_w;
+  int fb_h = native_fb_h;
+
+  if (g_aspectRatioLocked) {
+    // Try as if bounded on width.
+    fb_h = fb_w * g_aspectRatioH / g_aspectRatioW;
+    if (fb_h > native_fb_h) {
+      // Bounded on height instead.
+      fb_h = native_fb_h;
+      fb_w = fb_h * g_aspectRatioW / g_aspectRatioH;
+    }
+  }
+
   const float scale = SDL_GetWindowDisplayScale(g_window);
   return {
       .width = static_cast<uint32_t>(width),
       .height = static_cast<uint32_t>(height),
       .fb_width = static_cast<uint32_t>(fb_w),
       .fb_height = static_cast<uint32_t>(fb_h),
+      .native_fb_width = static_cast<uint32_t>(native_fb_w),
+      .native_fb_height = static_cast<uint32_t>(native_fb_h),
       .scale = scale,
   };
 }
@@ -342,5 +373,27 @@ void set_fullscreen(bool fullscreen) {
 }
 
 bool get_fullscreen() { return (SDL_GetWindowFlags(g_window) & SDL_WINDOW_FULLSCREEN) != 0u; }
+
+static void push_future_resize_event() {
+  SDL_Event event = {};
+  event.type = g_sdlResizeAspectRatioEvent;
+  TRY_WARN(SDL_PushEvent(&event), "Failed to push SDL event for future resize: {}", SDL_GetError());
+}
+
+void lock_aspect_ratio(int width, int height) {
+  g_aspectRatioLocked = true;
+  g_aspectRatioW = width;
+  g_aspectRatioH = height;
+
+  // Defer so that we don't try to reconfigure the surface in the middle of game logic.
+  push_future_resize_event();
+}
+
+void unlock_aspect_ratio() {
+  g_aspectRatioLocked = false;
+
+  // Defer so that we don't try to reconfigure the surface in the middle of game logic.
+  push_future_resize_event();
+}
 
 } // namespace aurora::window

--- a/lib/window.hpp
+++ b/lib/window.hpp
@@ -20,4 +20,6 @@ SDL_Renderer* get_sdl_renderer();
 void set_title(const char* title);
 void set_fullscreen(bool fullscreen);
 bool get_fullscreen();
+void lock_aspect_ratio(int width, int height);
+void unlock_aspect_ratio();
 }; // namespace aurora::window

--- a/tests/gx_test_stubs.cpp
+++ b/tests/gx_test_stubs.cpp
@@ -154,7 +154,7 @@ void queue(ConvRequest req) {}
 // --- Window stub ---
 #include "../lib/window.hpp"
 namespace aurora::window {
-AuroraWindowSize get_window_size() { return {640, 480, 640, 480, 1.0f}; }
+AuroraWindowSize get_window_size() { return {640, 480, 640, 480, 640, 480, 1.0f}; }
 } // namespace aurora::window
 
 // --- WebGPU C API stubs (prevent linker errors from wgpu:: destructors) ---


### PR DESCRIPTION
This leaves the imgui (so including OS) framebuffer alone.

AuroraWindowSize now has new fields for the native framebuffer, the aspect ratio controls modify the existing fields.