### PR TITLE
Avoid reopening file on every FileIO read/write

### DIFF
--- a/lib/card/Card.cpp
+++ b/lib/card/Card.cpp
@@ -827,6 +827,7 @@ void Card::format(ECardSlot id, ECardSize size, EEncoding encoding) {
     for (uint32_t i = 0; i < blockCount; ++i) {
       m_fileHandle.fileWrite(DummyBlock.get(), BlockSize, BlockSize * (i + 5));
     }
+    m_fileHandle.flush();
     m_dirty = false;
   }
 }
@@ -862,6 +863,7 @@ void Card::commit() {
     m_tmpBats[1].updateChecksum();
     m_tmpBats[1].swapEndian();
     m_fileHandle.fileWrite(m_tmpBats[1].raw.data(), BlockSize, BlockSize * 4);
+    m_fileHandle.flush();
     m_dirty = false;
   }
 }

--- a/lib/card/FileIO.cpp
+++ b/lib/card/FileIO.cpp
@@ -9,25 +9,36 @@ namespace aurora::card {
 
 FileIO::FileIO(std::string_view filename, bool truncate) {
   m_path = filename;
-  SDL_IOStream* stream = nullptr;
 
-  stream = fileOpen(m_path.c_str(), truncate ? "w+b" : "r+b");
+  m_stream = fileOpen(m_path.c_str(), truncate ? "w+b" : "r+b");
 
-  if (stream != nullptr) {
-    SDL_FlushIO(stream);
-    SDL_CloseIO(stream);
+  if (m_stream != nullptr) {
     m_ready = true;
+  }
+}
+
+FileIO::~FileIO() {
+  if (m_stream != nullptr) {
+    SDL_FlushIO(m_stream);
+    SDL_CloseIO(m_stream);
+    m_stream = nullptr;
   }
 }
 
 FileIO::FileIO(FileIO&& other) noexcept {
   m_path = std::move(other.m_path);
+  m_stream = std::exchange(other.m_stream, nullptr);
   m_ready = std::exchange(other.m_ready, false);
 }
 
 FileIO& FileIO::operator=(FileIO&& other) noexcept {
   if (this != &other) {
+    if (m_stream != nullptr) {
+      SDL_FlushIO(m_stream);
+      SDL_CloseIO(m_stream);
+    }
     m_path = std::move(other.m_path);
+    m_stream = std::exchange(other.m_stream, nullptr);
     m_ready = std::exchange(other.m_ready, false);
   }
   return *this;
@@ -38,28 +49,20 @@ bool FileIO::fileRead(void* buf, size_t length, off_t offset) {
     return false;
   }
 
-  SDL_IOStream* stream = fileOpen(m_path, "rb");
-  if (stream == nullptr) {
-    return false;
-  }
-
-  if (SDL_SeekIO(stream, offset, SDL_IO_SEEK_SET) < 0) {
-    SDL_CloseIO(stream);
+  if (SDL_SeekIO(m_stream, offset, SDL_IO_SEEK_SET) < 0) {
     return false;
   }
 
   size_t total = 0;
   auto* dst = static_cast<uint8_t*>(buf);
   while (total < length) {
-    const size_t read = SDL_ReadIO(stream, dst + total, length - total);
+    const size_t read = SDL_ReadIO(m_stream, dst + total, length - total);
     if (read == 0) {
-      SDL_CloseIO(stream);
       return false;
     }
     total += read;
   }
 
-  SDL_CloseIO(stream);
   return true;
 }
 
@@ -68,34 +71,27 @@ bool FileIO::fileWrite(const void* buf, size_t length, off_t offset) {
     return false;
   }
 
-  SDL_IOStream* stream = fileOpen(m_path, "r+b");
-  if (stream == nullptr) {
-    stream = fileOpen(m_path, "w+b");
-  }
-  if (stream == nullptr) {
-    return false;
-  }
-
-  if (SDL_SeekIO(stream, offset, SDL_IO_SEEK_SET) < 0) {
-    SDL_FlushIO(stream);
-    SDL_CloseIO(stream);
+  if (SDL_SeekIO(m_stream, offset, SDL_IO_SEEK_SET) < 0) {
     return false;
   }
 
   size_t total = 0;
   auto* src = static_cast<const uint8_t*>(buf);
   while (total < length) {
-    const size_t written = SDL_WriteIO(stream, src + total, length - total);
+    const size_t written = SDL_WriteIO(m_stream, src + total, length - total);
     if (written == 0) {
-      SDL_CloseIO(stream);
       return false;
     }
     total += written;
   }
 
-  SDL_FlushIO(stream);
-  SDL_CloseIO(stream);
   return true;
+}
+
+void FileIO::flush() {
+  if (m_stream != nullptr) {
+    SDL_FlushIO(m_stream);
+  }
 }
 
 FileIO::operator bool() const { return isReady(); }

--- a/lib/card/FileIO.hpp
+++ b/lib/card/FileIO.hpp
@@ -9,14 +9,15 @@ namespace aurora::card {
 
 class FileIO {
   std::string m_path;
+  SDL_IOStream* m_stream = nullptr;
   bool m_ready = false;
 
-  bool isReady() const { return m_ready && !m_path.empty(); };
+  bool isReady() const { return m_ready && m_stream != nullptr; };
 
 public:
   FileIO() = default;
   explicit FileIO(std::string_view filename, bool truncate = false);
-  ~FileIO() = default;
+  ~FileIO();
 
   FileIO(FileIO&& other) noexcept;
   FileIO& operator=(FileIO&& other) noexcept;
@@ -26,6 +27,7 @@ public:
   static SDL_IOStream* fileOpen(const std::string& path, const char* mode) {return path.empty() ? nullptr : SDL_IOFromFile(path.c_str(), mode);}
   bool fileRead(void* buf, size_t length, off_t offset);
   bool fileWrite(const void* buf, size_t length, off_t offset);
+  void flush();
   explicit operator bool() const;
 };
 


### PR DESCRIPTION
FileIO::fileRead/fileWrite open and close the file on every call, which causes noticeable slowdowns on Card::format().

Takes like a minute on an HDD and 10-15 seconds on an SSD to create the .raw file on the initial run, fixes that by just keeping the file open instead.