### PR TITLE
Cleanly shutdown aurora::input

### DIFF
--- a/lib/aurora.cpp
+++ b/lib/aurora.cpp
@@ -201,6 +201,7 @@ void shutdown() noexcept {
   gfx::shutdown();
   webgpu::shutdown();
 #endif
+  input::shutdown();
   window::shutdown();
 }
 

--- a/lib/input.cpp
+++ b/lib/input.cpp
@@ -156,4 +156,14 @@ void get_mouse_scroll(float* scrollX, float* scrollY) noexcept {
   *scrollY = g_MouseStatus.scrollY;
 }
 
+void shutdown() noexcept {
+  // Upon shutdown we want to ensure all controllers are in a default state, so force all rumble supporting controllers
+  // to shut off their rumble motors. 
+  for (const auto& controller : g_GameControllers) {
+    if (!controller.second.m_hasRumble) {
+      continue;
+    }
+    controller_rumble(controller.first, 0, 0, 0);
+  }
+}
 } // namespace aurora::input

--- a/lib/input.hpp
+++ b/lib/input.hpp
@@ -56,4 +56,6 @@ extern absl::flat_hash_map<Uint32, GameController> g_GameControllers;
 
 void set_mouse_scroll(float scrollX, float scrollY) noexcept;
 void get_mouse_scroll(float* scrollX, float* scrollY) noexcept;
+
+void shutdown() noexcept;
 } // namespace aurora::input


### PR DESCRIPTION
Cleanly shutdown aurora::input by telling all registered controllers to stop their rumble motors.

This should address "ghost rumble" if the game is exited just after a rumble command is dispatched.