### PR TITLE
Allow per-pixel lighting to be changed at runtime

### DIFF
--- a/include/dolphin/gx/GXAurora.h
+++ b/include/dolphin/gx/GXAurora.h
@@ -59,6 +59,10 @@ extern "C" {
 
 #define GX_LOAD_AURORA_DESTROY_TLUT 0x0033
 
+/**
+ * Sets whether per-pixel lighting is enabled. Must be followed by a single-byte value (1 or 0).
+ */
+#define GX_LOAD_AURORA_PIXEL_LIGHTING 0x0040
 
 /*
  * Debug marker stuff
@@ -121,6 +125,11 @@ void GXCreateFrameBuffer(u32 width, u32 height);
  * Must be called after GXCreateFrameBuffer() to resume normal rendering.
  */
 void GXRestoreFrameBuffer(void);
+
+/**
+ * Sets whether per-pixel lighting is enabled.
+ */
+void GXSetPixelLighting(bool enabled);
 
 #if __cplusplus
 }

--- a/lib/dolphin/gx/GXAurora.cpp
+++ b/lib/dolphin/gx/GXAurora.cpp
@@ -84,6 +84,11 @@ void GXSetScissorRender(u32 left, u32 top, u32 wd, u32 ht) {
   GX_WRITE_U32(ht);
 }
 
+void GXSetPixelLighting(bool enabled) {
+  GX_WRITE_AURORA(GX_LOAD_AURORA_PIXEL_LIGHTING);
+  GX_WRITE_U8(enabled ? 1 : 0);
+}
+
 void GXCreateFrameBuffer(u32 width, u32 height) {
   aurora::gx::fifo::drain();
   aurora::gfx::begin_offscreen(width, height);

--- a/lib/gx/command_processor.cpp
+++ b/lib/gx/command_processor.cpp
@@ -1784,6 +1784,9 @@ void handle_aurora(const u8* data, u32& pos, u32 size, bool bigEndian) {
   } else if (subCmd == GX_LOAD_AURORA_DEBUG_MARKER_INSERT) {
     auto label = read_string(data, pos, size, bigEndian);
     gfx::insert_debug_marker(std::move(label));
+  } else if (subCmd == GX_LOAD_AURORA_PIXEL_LIGHTING) {
+    g_gxState.perPixelLighting = data[pos++] != 0;
+    g_gxState.stateDirty = true;
   }
 
   else {

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -776,10 +776,13 @@ void populate_pipeline_config(PipelineConfig& config, GXPrimitive primitive, GXV
     config.shaderConfig.indStages[i] = g_gxState.indStages[i];
   }
   config.shaderConfig.numIndStages = g_gxState.numIndStages;
+
+  bool anyLightingEnabled = false;
   for (u8 i = 0; i < MaxColorChannels; ++i) {
     const auto& cc = g_gxState.colorChannelConfig[i];
     if (cc.lightingEnabled) {
       config.shaderConfig.colorChannels[i] = cc;
+      anyLightingEnabled = true;
     } else {
       // Only matSrc matters when lighting disabled
       config.shaderConfig.colorChannels[i] = {
@@ -787,6 +790,10 @@ void populate_pipeline_config(PipelineConfig& config, GXPrimitive primitive, GXV
       };
     }
   }
+
+  // Only set this bit if lighting actually is enabled, avoid creating unnecessary pipeline permutations.
+  config.shaderConfig.perPixelLighting = anyLightingEnabled && g_gxState.perPixelLighting;
+
   for (u8 i = 0; i < g_gxState.numTexGens; ++i) {
     config.shaderConfig.tcgs[i] = g_gxState.tcgs[i];
   }

--- a/lib/gx/gx.hpp
+++ b/lib/gx/gx.hpp
@@ -47,7 +47,6 @@ constexpr float GX_LARGE_NUMBER = -1048576.0f;
 namespace aurora::gx {
 constexpr bool EnableNormalVisualization = false;
 constexpr bool EnableDebugPrints = false;
-constexpr bool UsePerPixelLighting = true;
 constexpr bool UseReversedZ = true;
 
 constexpr u32 MaxTextures = GX_MAX_TEXMAP;
@@ -294,6 +293,7 @@ struct GXState {
   Mat4x4<float> proj;
   GXProjectionType projType; // for GXGetProjectionv
   FogState fog;
+  bool perPixelLighting = false;
   GXCullMode cullMode = GX_CULL_BACK;
   u8 lineWidth = 0;
   u8 pointSize = 0;
@@ -438,7 +438,8 @@ struct ShaderConfig {
   u8 fogType = GX_FOG_NONE;
   u8 vtxStride = 0;
   u8 lineMode : 2 = 0; // 1 = GX_LINES, 2 = GX_LINESTRIP, 3 = GX_POINTS
-  u8 pad1 : 6 = 0;
+  bool perPixelLighting : 1 = false;
+  u8 pad1 : 5 = 0;
   u8 pad2 = 0;
   std::array<AttrConfig, MaxVtxAttr> attrs;
   std::array<TevSwap, MaxTevSwap> tevSwapTable;

--- a/lib/gx/shader.cpp
+++ b/lib/gx/shader.cpp
@@ -592,7 +592,7 @@ auto lighting_func(const ShaderConfig& config, const ColorChannelConfig& cc, u8 
   std::string_view swizzle = alpha ? ".a"sv : ""sv;
   std::string outVar;
   std::string_view posVar;
-  if (UsePerPixelLighting) {
+  if (config.perPixelLighting) {
     outVar = fmt::format("rast{}", i);
     posVar = "in.mv_pos"sv;
   } else {
@@ -601,7 +601,7 @@ auto lighting_func(const ShaderConfig& config, const ColorChannelConfig& cc, u8 
   }
   std::string ambSrc, matSrc;
   if (cc.ambSrc == GX_SRC_VTX) {
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       ambSrc = fmt::format("in.clr{}", i);
     } else {
       ambSrc = vtx_attr(config, static_cast<GXAttr>(GX_VA_CLR0 + i));
@@ -610,7 +610,7 @@ auto lighting_func(const ShaderConfig& config, const ColorChannelConfig& cc, u8 
     ambSrc = fmt::format("ubuf.cc{0}{1}_amb", i, alpha ? "a"sv : ""sv);
   }
   if (cc.matSrc == GX_SRC_VTX) {
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       matSrc = fmt::format("in.clr{}", i);
     } else {
       matSrc = vtx_attr(config, static_cast<GXAttr>(GX_VA_CLR0 + i));
@@ -632,7 +632,7 @@ auto lighting_func(const ShaderConfig& config, const ColorChannelConfig& cc, u8 
           var dist_attn = dot(light.dist_att, vec3f(1.0, dist, dist2));
           attn = max(0.0, cos_attn / dist_attn);)""");
   } else if (cc.attnFn == GX_AF_SPEC) {
-    std::string_view normal = UsePerPixelLighting ? "in.mv_nrm"sv : "mv_nrm"sv;
+    std::string_view normal = config.perPixelLighting ? "in.mv_nrm"sv : "mv_nrm"sv;
     std::string dist_attn = diffFn != GX_DF_NONE
                                 ? "max(0.0, dot(normalize(light.dist_att), vec3f(1.0, attn, attn * attn)));"
                                 : "max(0.0, dot(light.dist_att, vec3f(1.0, attn, attn * attn)));";
@@ -647,13 +647,13 @@ auto lighting_func(const ShaderConfig& config, const ColorChannelConfig& cc, u8 
   if (diffFn == GX_DF_NONE) {
     lightDiffFn = "1.0"sv;
   } else if (diffFn == GX_DF_SIGN) {
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       lightDiffFn = "dot(ldir, in.mv_nrm)"sv;
     } else {
       lightDiffFn = "dot(ldir, mv_nrm)"sv;
     }
   } else if (diffFn == GX_DF_CLAMP) {
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       lightDiffFn = "max(0.0, dot(ldir, in.mv_nrm))"sv;
     } else {
       lightDiffFn = "max(0.0, dot(ldir, mv_nrm))"sv;
@@ -936,7 +936,7 @@ wgpu::ShaderModule build_shader(const ShaderConfig& config) noexcept {
         "    cos_att: vec3f,\n"
         "    dist_att: vec3f,\n"
         "};";
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       vtxOutAttrs += fmt::format("\n    @location({}) mv_pos: vec3f,", vtxOutIdx++);
       vtxOutAttrs += fmt::format("\n    @location({}) mv_nrm: vec3f,", vtxOutIdx++);
       vtxXfrAttrs += fmt::format(FMT_STRING(R"""(
@@ -966,7 +966,7 @@ wgpu::ShaderModule build_shader(const ShaderConfig& config) noexcept {
     }
 
     // Output vertex color if necessary
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       if ((cc.lightingEnabled && cc.ambSrc == GX_SRC_VTX) || cc.matSrc == GX_SRC_VTX ||
           (cca.lightingEnabled && cca.ambSrc == GX_SRC_VTX) || cca.matSrc == GX_SRC_VTX) {
         vtxOutAttrs += fmt::format("\n    @location({}) clr{}: vec4f,", vtxOutIdx++, i);
@@ -974,7 +974,7 @@ wgpu::ShaderModule build_shader(const ShaderConfig& config) noexcept {
       }
     }
 
-    if (UsePerPixelLighting) {
+    if (config.perPixelLighting) {
       fragmentFnPre += fmt::format("\n    var rast{}: vec4f;", i);
       fragmentFnPre += lighting_func(config, cc, i, false);
       fragmentFnPre += lighting_func(config, cca, i, true);


### PR DESCRIPTION
Just make the constexpr part of the pipeline config instead, easy.

Defaults to off, changed in GX state via new Aurora FIFO command.