### PR TITLE
Add support for binding keys to pad buttons

### DIFF
--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -70,6 +70,7 @@ extern "C" {
 #endif
 
 #define PAD_NATIVE_BUTTON_INVALID 0xFFFFFFFF
+#define PAD_KEY_MASK 0x80000000
 
 typedef struct PADStatus {
   u16 button;
@@ -147,8 +148,12 @@ s32 PADGetIndexForPort(u32 port);
 void PADGetVidPid(u32 port, u32* vid, u32* pid);
 void PADClearPort(u32 port);
 const char* PADGetName(u32 port);
+// All the button mapping functions can be used to set either key or button bindings.
+// To set a button binding simply use the SDL pad value
+// To set a key value the top bit of the scancode must be set.
 void PADSetButtonMapping(u32 port, PADButtonMapping mapping);
 void PADSetAllButtonMappings(u32 port, PADButtonMapping buttons[PAD_BUTTON_COUNT]);
+void PADSetScancodeBinding(u32 port, PADButton, u16 scancode);
 PADButtonMapping* PADGetButtonMappings(u32 port, u32* buttonCount);
 void PADSetAxisMapping(u32 port, PADAxisMapping mapping);
 void PADSetAllAxisMappings(u32 port, PADAxisMapping axes[PAD_AXIS_COUNT]);

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -71,6 +71,8 @@ extern "C" {
 
 #define PAD_NATIVE_BUTTON_INVALID 0xFFFFFFFF
 #define PAD_KEY_MASK 0x80000000
+#define PADIsScancode(x) (((s32)x & PAD_KEY_MASK) == PAD_KEY_MASK)
+#define PADCreateScancode(x) ((s32)x | PAD_KEY_MASK)
 
 typedef struct PADStatus {
   u16 button;

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -155,7 +155,7 @@ const char* PADGetName(u32 port);
 // To set a key value the top bit of the scancode must be set.
 void PADSetButtonMapping(u32 port, PADButtonMapping mapping);
 void PADSetAllButtonMappings(u32 port, PADButtonMapping buttons[PAD_BUTTON_COUNT]);
-void PADSetScancodeBinding(u32 port, PADButton, u16 scancode);
+BOOL PADSetScancodeBinding(u32 port, PADButton, u16 scancode);
 PADButtonMapping* PADGetButtonMappings(u32 port, u32* buttonCount);
 void PADSetAxisMapping(u32 port, PADAxisMapping mapping);
 void PADSetAllAxisMappings(u32 port, PADAxisMapping axes[PAD_AXIS_COUNT]);

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -907,13 +907,18 @@ BOOL PADIsGCAdapter(u32 port) {
   return ctrl->m_isGameCube;
 }
 
-void PADSetScancodeBinding(u32 port, PADButton button, s32 scancode) {
+BOOL PADSetScancodeBinding(u32 port, PADButton button, s32 scancode) {
   auto* ctrl = aurora::input::get_controller_for_player(port);
   if (ctrl == nullptr) {
-    return;
+    return FALSE;
   }
-  auto* mapping =
-      std::find_if(ctrl->m_buttonMapping.begin(), ctrl->m_buttonMapping.end(),
-                   [&button](const PADButtonMapping& mapping) { return mapping.padButton == button; });
-  mapping->nativeButton = scancode | PAD_KEY_MASK;
+  
+  for (auto& mapping : ctrl->m_buttonMapping) {
+    if (mapping.padButton == button) {
+      mapping.nativeButton = scancode | PAD_KEY_MASK;
+      return TRUE;
+    }
+  }
+
+  return FALSE;
 }

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -230,8 +230,15 @@ uint32_t PADRead(PADStatus* status) {
     std::for_each(
         controller->m_buttonMapping.begin(), controller->m_buttonMapping.end(),
         [&controller, &i, &status](const auto& mapping) {
-          if (SDL_GetGamepadButton(controller->m_controller, static_cast<SDL_GamepadButton>(mapping.nativeButton))) {
-            status[i].button |= mapping.padButton;
+          if (!(mapping.nativeButton & PAD_KEY_MASK)) {
+            if (SDL_GetGamepadButton(controller->m_controller, static_cast<SDL_GamepadButton>(mapping.nativeButton))) {
+              status[i].button |= mapping.padButton;
+            }
+          } else if (mapping.nativeButton != PAD_NATIVE_BUTTON_INVALID) {
+            const bool* state = SDL_GetKeyboardState(nullptr);
+            if (state[mapping.nativeButton & ~PAD_KEY_MASK]) {
+              status[i].button |= mapping.padButton;
+            }
           }
         });
 
@@ -898,4 +905,15 @@ BOOL PADIsGCAdapter(u32 port) {
     return FALSE;
   }
   return ctrl->m_isGameCube;
+}
+
+void PADSetScancodeBinding(u32 port, PADButton button, s32 scancode) {
+  auto* ctrl = aurora::input::get_controller_for_player(port);
+  if (ctrl == nullptr) {
+    return;
+  }
+  PADButtonMapping* mapping =
+      std::find_if(ctrl->m_buttonMapping.begin(), ctrl->m_buttonMapping.end(),
+                   [&button](const PADButtonMapping& mapping) { return mapping.padButton == button; });
+  mapping->nativeButton = scancode | 0x80000000;
 }

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -912,7 +912,7 @@ void PADSetScancodeBinding(u32 port, PADButton button, s32 scancode) {
   if (ctrl == nullptr) {
     return;
   }
-  PADButtonMapping* mapping =
+  auto* mapping =
       std::find_if(ctrl->m_buttonMapping.begin(), ctrl->m_buttonMapping.end(),
                    [&button](const PADButtonMapping& mapping) { return mapping.padButton == button; });
   mapping->nativeButton = scancode | PAD_KEY_MASK;

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -915,5 +915,5 @@ void PADSetScancodeBinding(u32 port, PADButton button, s32 scancode) {
   PADButtonMapping* mapping =
       std::find_if(ctrl->m_buttonMapping.begin(), ctrl->m_buttonMapping.end(),
                    [&button](const PADButtonMapping& mapping) { return mapping.padButton == button; });
-  mapping->nativeButton = scancode | 0x80000000;
+  mapping->nativeButton = scancode | PAD_KEY_MASK;
 }


### PR DESCRIPTION
Very preliminary and needs testing, I haven't added any scancode enums just yet

We need to discuss how we want to handle the scancode enumerator before we add it.

We really have only 3 options:
1) Roll our own and create a mapping
2) Copy SDL's and direct cast
3) Keep it the way it is.