### PR TITLE
gx: Fix scissor width/height handling

### DIFF
--- a/lib/dolphin/gx/GXCull.cpp
+++ b/lib/dolphin/gx/GXCull.cpp
@@ -4,8 +4,8 @@
 extern "C" {
 
 void GXSetScissor(u32 left, u32 top, u32 width, u32 height) {
-  const u32 tp = top + 340;
-  const u32 lf = left + 340;
+  const u32 tp = top + 342;
+  const u32 lf = left + 342;
   const u32 bm = tp + height - 1;
   const u32 rt = lf + width - 1;
 

--- a/lib/dolphin/gx/GXGet.cpp
+++ b/lib/dolphin/gx/GXGet.cpp
@@ -243,8 +243,8 @@ void GXGetScissor(u32* left, u32* top, u32* wd, u32* ht) {
   const u32 bm = GET_REG_FIELD(__gx->suScis1, 11, 0);
   const u32 rt = GET_REG_FIELD(__gx->suScis1, 11, 12);
 
-  *left = lf - 340;
-  *top = tp - 340;
+  *left = lf - 342;
+  *top = tp - 342;
   *wd = rt - lf + 1;
   *ht = bm - tp + 1;
 }

--- a/lib/gx/command_processor.cpp
+++ b/lib/gx/command_processor.cpp
@@ -634,13 +634,13 @@ static void handle_bp(u32 value, bool bigEndian) {
   case 0x21: {
     const u32 scis0 = g_gxState.bpRegCache[0x20];
     const u32 scis1 = g_gxState.bpRegCache[0x21];
-    const int32_t tp = static_cast<int32_t>(bp_get(scis0, 11, 0));
-    const int32_t lf = static_cast<int32_t>(bp_get(scis0, 11, 12));
-    const int32_t bm = static_cast<int32_t>(bp_get(scis1, 11, 0));
-    const int32_t rt = static_cast<int32_t>(bp_get(scis1, 11, 12));
-    if (rt >= lf && bm >= tp) {
-      set_logical_scissor({lf - 340, tp - 340, rt - lf + 1, bm - tp + 1});
-    }
+    const int32_t tp = static_cast<int32_t>(bp_get(scis0, 11, 0)) - 342;
+    const int32_t lf = static_cast<int32_t>(bp_get(scis0, 11, 12)) - 342;
+    const int32_t bm = static_cast<int32_t>(bp_get(scis1, 11, 0)) - 342;
+    const int32_t rt = static_cast<int32_t>(bp_get(scis1, 11, 12)) - 342;
+    const int32_t wd = std::max(rt - lf + 1, 0);
+    const int32_t ht = std::max(bm - tp + 1, 0);
+    set_logical_scissor({lf, tp, wd, ht});
     break;
   }
 


### PR DESCRIPTION
* Not a big deal if we're using our own lib, but officially, the scissor offset is 342, not 340.
* aurora was subtracting the scissor offset for lt/tp, but not for rt/bm; fix that.
* Handle empty scissors