### PR TITLE
Switch RmlUi FileInterface to custom SDL version

### DIFF
--- a/cmake/aurora_core.cmake
+++ b/cmake/aurora_core.cmake
@@ -29,6 +29,7 @@ if(AURORA_ENABLE_RMLUI)
             lib/rmlui/RmlUi_Backend_Aurora.cpp
             lib/rmlui/WebGPURenderInterface.cpp
             lib/rmlui/SystemInterface_Aurora.cpp
+            lib/rmlui/FileInterface_SDL.cpp
     )
     target_link_libraries(aurora_core PUBLIC rmlui)
 

--- a/lib/rmlui.cpp
+++ b/lib/rmlui.cpp
@@ -7,6 +7,7 @@
 #include "window.hpp"
 #include "internal.hpp"
 #include "imgui.hpp"
+#include "rmlui/FileInterface_SDL.h"
 #include "rmlui/SystemInterface_Aurora.h"
 #include "rmlui/WebGPURenderInterface.hpp"
 #include "webgpu/gpu.hpp"
@@ -21,6 +22,7 @@ WebGPURenderInterface* get_render_interface() noexcept {
 } // namespace
 
 Rml::Context* g_context = nullptr;
+FileInterface_SDL* g_fileInterface = nullptr;
 
 void initialize(const AuroraWindowSize& size) noexcept {
   int width = static_cast<int>(size.native_fb_width);
@@ -30,9 +32,12 @@ void initialize(const AuroraWindowSize& size) noexcept {
     return;
   }
 
+  g_fileInterface = new FileInterface_SDL();
+
   auto* renderInterface = get_render_interface();
   Rml::SetSystemInterface(Backend::GetSystemInterface());
   Rml::SetRenderInterface(renderInterface);
+  Rml::SetFileInterface(g_fileInterface);
 
   renderInterface->SetWindowSize({width, height});
   renderInterface->SetRenderTargetFormat(webgpu::g_graphicsConfig.surfaceConfiguration.format);

--- a/lib/rmlui/FileInterface_SDL.cpp
+++ b/lib/rmlui/FileInterface_SDL.cpp
@@ -10,7 +10,6 @@ Module Log("aurora::rmlui::FileInterface");
 } // namespace
 
 Rml::FileHandle FileInterface_SDL::Open(const Rml::String& path) {
-  Log.debug("Opening File: {}", path);
   auto stream = SDL_IOFromFile(path.c_str(), "r+b");
 
   if (stream == nullptr) {
@@ -18,13 +17,10 @@ Rml::FileHandle FileInterface_SDL::Open(const Rml::String& path) {
     return 0;
   }
 
-  Log.debug("File Handle Addr: {}", (Rml::FileHandle)stream);
-
   return (Rml::FileHandle)stream;
 }
 
 void FileInterface_SDL::Close(Rml::FileHandle file) {
-  Log.debug("Closing File: {}", file);
   if (file != 0) {
     auto stream = (SDL_IOStream*)file;
     SDL_CloseIO(stream);
@@ -48,7 +44,7 @@ size_t FileInterface_SDL::Read(void* buffer, size_t size, Rml::FileHandle file) 
         Log.error("Read failed! Reason: {}", SDL_GetError());
         SDL_CloseIO(stream);
         return total;
-      }else {
+      } else {
         return size;
       }
     }
@@ -65,8 +61,6 @@ bool FileInterface_SDL::Seek(Rml::FileHandle file, long offset, int origin) {
   }
 
   auto stream = (SDL_IOStream*)file;
-
-  Log.debug("Seeking File: {} (Offset: {} Origin: {})", file, offset, origin);
 
   if (SDL_SeekIO(stream, offset, (SDL_IOWhence)origin) < 0) {
     Log.warn("Seek failed! Reason: {}", SDL_GetError());
@@ -97,4 +91,4 @@ size_t FileInterface_SDL::Length(Rml::FileHandle file) {
   return SDL_GetIOSize(stream);
 }
 
-}
+} // namespace aurora::rmlui

--- a/lib/rmlui/FileInterface_SDL.cpp
+++ b/lib/rmlui/FileInterface_SDL.cpp
@@ -1,0 +1,100 @@
+#include "FileInterface_SDL.h"
+
+#include <SDL3/SDL_iostream.h>
+#include "../logging.hpp"
+
+namespace aurora::rmlui {
+
+namespace {
+Module Log("aurora::rmlui::FileInterface");
+} // namespace
+
+Rml::FileHandle FileInterface_SDL::Open(const Rml::String& path) {
+  Log.debug("Opening File: {}", path);
+  auto stream = SDL_IOFromFile(path.c_str(), "r+b");
+
+  if (stream == nullptr) {
+    Log.error("Could not open file! Reason: {}", SDL_GetError());
+    return 0;
+  }
+
+  Log.debug("File Handle Addr: {}", (Rml::FileHandle)stream);
+
+  return (Rml::FileHandle)stream;
+}
+
+void FileInterface_SDL::Close(Rml::FileHandle file) {
+  Log.debug("Closing File: {}", file);
+  if (file != 0) {
+    auto stream = (SDL_IOStream*)file;
+    SDL_CloseIO(stream);
+  }
+}
+
+size_t FileInterface_SDL::Read(void* buffer, size_t size, Rml::FileHandle file) {
+  if (file == 0) {
+    Log.warn("Attempted to read with null file handle!");
+    return 0;
+  }
+
+  auto stream = (SDL_IOStream*)file;
+
+  size_t total = 0;
+  auto* dst = static_cast<uint8_t*>(buffer);
+  while (total < size) {
+    const size_t read = SDL_ReadIO(stream, dst + total, size - total);
+    if (read == 0) {
+      if (SDL_GetIOStatus(stream) != SDL_IO_STATUS_EOF) {
+        Log.error("Read failed! Reason: {}", SDL_GetError());
+        SDL_CloseIO(stream);
+        return total;
+      }else {
+        return size;
+      }
+    }
+    total += read;
+  }
+
+  return total;
+}
+
+bool FileInterface_SDL::Seek(Rml::FileHandle file, long offset, int origin) {
+  if (file == 0) {
+    Log.warn("Attempted to seek with null file handle!");
+    return 0;
+  }
+
+  auto stream = (SDL_IOStream*)file;
+
+  Log.debug("Seeking File: {} (Offset: {} Origin: {})", file, offset, origin);
+
+  if (SDL_SeekIO(stream, offset, (SDL_IOWhence)origin) < 0) {
+    Log.warn("Seek failed! Reason: {}", SDL_GetError());
+    SDL_FlushIO(stream);
+    SDL_CloseIO(stream);
+    return false;
+  }
+
+  return true;
+}
+
+size_t FileInterface_SDL::Tell(Rml::FileHandle file) {
+  if (file == 0) {
+    Log.warn("Attempted to tell with null file handle!");
+    return 0;
+  }
+
+  return SDL_TellIO((SDL_IOStream*)file);
+}
+
+size_t FileInterface_SDL::Length(Rml::FileHandle file) {
+  if (file == 0) {
+    Log.warn("Attempted to get length with null file handle!");
+    return 0;
+  }
+
+  auto stream = (SDL_IOStream*)file;
+  return SDL_GetIOSize(stream);
+}
+
+}

--- a/lib/rmlui/FileInterface_SDL.h
+++ b/lib/rmlui/FileInterface_SDL.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <RmlUi/Core/FileInterface.h>
+
+namespace aurora::rmlui {
+
+class FileInterface_SDL : public Rml::FileInterface {
+public:
+  FileInterface_SDL() = default;
+
+  Rml::FileHandle Open(const Rml::String& path) override;
+  void Close(Rml::FileHandle file) override;
+  size_t Read(void* buffer, size_t size, Rml::FileHandle file) override;
+  bool Seek(Rml::FileHandle file, long offset, int origin) override;
+  size_t Tell(Rml::FileHandle file) override;
+
+  size_t Length(Rml::FileHandle file) override;
+};
+
+}


### PR DESCRIPTION
This fixes android not properly accessing asset system through SDL, as the default file interface uses the standard C api, which on android is directed to the apps data directory.