### PR TITLE
Truncate instead of flooring in `calculate_inner_box`

### DIFF
--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -259,9 +259,9 @@ std::tuple<float, float, float, float> calculate_inner_box(const int targetWidth
     const auto scale = std::min(static_cast<float>(targetWidth) / static_cast<float>(logicalFbWidth),
                                 static_cast<float>(targetHeight) / static_cast<float>(logicalFbHeight));
     const auto offsetX =
-        std::floor((static_cast<float>(targetWidth) - static_cast<float>(logicalFbWidth) * scale) * 0.5f);
+        std::trunc((static_cast<float>(targetWidth) - static_cast<float>(logicalFbWidth) * scale) * 0.5f);
     const auto offsetY =
-        std::floor((static_cast<float>(targetHeight) - static_cast<float>(logicalFbHeight) * scale) * 0.5f);
+        std::trunc((static_cast<float>(targetHeight) - static_cast<float>(logicalFbHeight) * scale) * 0.5f);
     return {
         offsetX,
         offsetY,


### PR DESCRIPTION
In some cases, floating point error causes the pre-rounded values for `offsetX` or `offsetY` to be ever-so-slightly less than zero. This floors to a negative value, which shouldn't be possible and causes a mismatch between viewports and scissors due to clamping for the latter. We can round towards zero to alleviate this.