### PR TITLE
Add controller charge state and ext button support

### DIFF
--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -101,7 +101,7 @@ typedef struct PADStatus {
   u8 analogB;
   s8 err;
 #ifdef TARGET_PC
-  u16 extButtons;
+  u16 extButton;
 #endif
 } PADStatus;
 

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -90,7 +90,7 @@ extern "C" {
 #define PAD_NATIVE_BUTTON_INVALID 0xFFFFFFFF
 
 typedef struct PADStatus {
-  u16 buttons;
+  u16 button;
   s8 stickX;
   s8 stickY;
   s8 substickX;

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -40,6 +40,24 @@
 #define PAD_BUTTON_Y 0x0800
 #define PAD_BUTTON_MENU 0x1000
 #define PAD_BUTTON_START 0x1000
+#ifdef TARGET_PC
+#define PAD_BUTTON_BACK 0x0002000
+#define PAD_BUTTON_GUIDE 0x0004000
+#define PAD_BUTTON_MISC1 0x0008000
+#define PAD_BUTTON_MISC2 0x0010000
+#define PAD_BUTTON_MISC3 0x0020000
+#define PAD_BUTTON_MISC4 0x0040000
+#define PAD_BUTTON_MISC5 0x0080000
+#define PAD_BUTTON_MISC6 0x0100000
+#define PAD_BUTTON_RIGHT_PADDLE1 0x0200000
+#define PAD_BUTTON_LEFT_PADDLE1 0x0400000
+#define PAD_BUTTON_RIGHT_PADDLE2 0x0800000
+#define PAD_BUTTON_LEFT_PADDLE2 0x1000000
+#define PAD_BUTTON_RIGHT_STICK 0x2000000
+#define PAD_BUTTON_LEFT_STICK 0x4000000
+#define PAD_BUTTON_TOUCHPAD 0x8000000
+#define PAD_EXT_BUTTON_COUNT 15
+#endif
 
 #define PAD_BUTTON_COUNT 12
 
@@ -72,7 +90,7 @@ extern "C" {
 #define PAD_NATIVE_BUTTON_INVALID 0xFFFFFFFF
 
 typedef struct PADStatus {
-  u16 button;
+  u16 buttons;
   s8 stickX;
   s8 stickY;
   s8 substickX;
@@ -82,6 +100,9 @@ typedef struct PADStatus {
   u8 analogA;
   u8 analogB;
   s8 err;
+#ifdef TARGET_PC
+  u16 extButtons;
+#endif
 } PADStatus;
 
 typedef enum PADAxisSign {

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -129,12 +129,12 @@ void PADControlAllMotors(const u32* cmdArr);
 void PADSetAnalogMode(u32 mode);
 
 #ifdef TARGET_PC
-#define PAD_KEY_INVALID      (-1)
-#define PAD_KEY_MOUSE_LEFT   (-2)
+#define PAD_KEY_INVALID (-1)
+#define PAD_KEY_MOUSE_LEFT (-2)
 #define PAD_KEY_MOUSE_MIDDLE (-3)
-#define PAD_KEY_MOUSE_RIGHT  (-4)
-#define PAD_KEY_MOUSE_X1     (-5)
-#define PAD_KEY_MOUSE_X2     (-6)
+#define PAD_KEY_MOUSE_RIGHT (-4)
+#define PAD_KEY_MOUSE_X1 (-5)
+#define PAD_KEY_MOUSE_X2 (-6)
 typedef u16 PADButton;
 typedef u16 PADAxis;
 
@@ -159,12 +159,10 @@ typedef struct PADDeadZones {
   u16 rightTriggerActivationZone;
 } PADDeadZones;
 
-
 typedef struct PADButtonMapping {
   u32 nativeButton;
   PADButton padButton;
 } PADButtonMapping;
-
 
 typedef struct PADAxisMapping {
   PADSignedNativeAxis nativeAxis;
@@ -252,6 +250,17 @@ BOOL PADGetSensorData(u32 port, PADSensorType sensor, f32* data, int nValues);
 BOOL PADSetRumbleIntensity(u32 port, u16 low, u16 high);
 BOOL PADGetRumbleIntensity(u32 port, u16* low, u16* high);
 BOOL PADSupportsRumbleIntensity(u32 port);
+
+typedef enum PADBatteryState {
+  PAD_BATTERYSTATE_ERROR = -1,
+  PAD_BATTERYSTATE_UNKNOWN,
+  PAD_BATTERYSTATE_ON_BATTERY,
+  PAD_BATTERYSTATE_NO_BATTERY,
+  PAD_BATTERYSTATE_CHARGING,
+  PAD_BATTERYSTATE_CHARGED,
+} PADBatteryState;
+
+PADBatteryState PADGetBatteryState(u32 port, f32* perc);
 
 #endif
 

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -136,6 +136,7 @@ void PADSetAnalogMode(u32 mode);
 #define PAD_KEY_MOUSE_X1 (-5)
 #define PAD_KEY_MOUSE_X2 (-6)
 typedef u16 PADButton;
+typedef u32 PADExtButton;
 typedef u16 PADAxis;
 
 typedef struct PADKeyButtonBinding {

--- a/include/dolphin/pad.h
+++ b/include/dolphin/pad.h
@@ -101,7 +101,7 @@ typedef struct PADStatus {
   u8 analogB;
   s8 err;
 #ifdef TARGET_PC
-  u16 extButton;
+  u32 extButton;
 #endif
 } PADStatus;
 

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -463,7 +463,7 @@ uint32_t PADRead(PADStatus* status) {
           });
       
       // TODO: Add serializable mappings for these (probably not necessary)?
-      static constexpr std::array<std::pair<SDL_GamepadButton, PADButton>, PAD_EXT_BUTTON_COUNT> kExtButtonMappings{
+      static constexpr std::array<std::pair<SDL_GamepadButton, PADExtButton>, PAD_EXT_BUTTON_COUNT> kExtButtonMappings{
           {
             {SDL_GAMEPAD_BUTTON_BACK, PAD_BUTTON_BACK},
             {SDL_GAMEPAD_BUTTON_GUIDE, PAD_BUTTON_GUIDE},

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -461,6 +461,33 @@ uint32_t PADRead(PADStatus* status) {
               status[i].button |= mapping.padButton;
             }
           });
+      
+      // TODO: Add serializable mappings for these (probably not necessary)?
+      static constexpr std::array<std::pair<SDL_GamepadButton, PADButton>, PAD_EXT_BUTTON_COUNT> kExtButtonMappings{
+          {
+            {SDL_GAMEPAD_BUTTON_BACK, PAD_BUTTON_BACK},
+            {SDL_GAMEPAD_BUTTON_GUIDE, PAD_BUTTON_GUIDE},
+            {SDL_GAMEPAD_BUTTON_MISC1, PAD_BUTTON_MISC1},
+            {SDL_GAMEPAD_BUTTON_MISC2, PAD_BUTTON_MISC2},
+            {SDL_GAMEPAD_BUTTON_MISC3, PAD_BUTTON_MISC3},
+            {SDL_GAMEPAD_BUTTON_MISC4, PAD_BUTTON_MISC4},
+            {SDL_GAMEPAD_BUTTON_MISC5, PAD_BUTTON_MISC5},
+            {SDL_GAMEPAD_BUTTON_MISC6, PAD_BUTTON_MISC6},
+            {SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1, PAD_BUTTON_RIGHT_PADDLE1},
+            {SDL_GAMEPAD_BUTTON_LEFT_PADDLE1, PAD_BUTTON_LEFT_PADDLE1},
+            {SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2, PAD_BUTTON_RIGHT_PADDLE2},
+            {SDL_GAMEPAD_BUTTON_LEFT_PADDLE2, PAD_BUTTON_LEFT_PADDLE2},
+            {SDL_GAMEPAD_BUTTON_RIGHT_STICK, PAD_BUTTON_RIGHT_STICK},
+            {SDL_GAMEPAD_BUTTON_LEFT_STICK, PAD_BUTTON_LEFT_STICK},
+            {SDL_GAMEPAD_BUTTON_TOUCHPAD, PAD_BUTTON_TOUCHPAD},
+          }
+      };
+      
+      for (const auto& mapping : kExtButtonMappings) {
+        if (SDL_GetGamepadButton(controller->m_controller, mapping.first)) {
+          status[i].extButtons |= mapping.second;
+        }
+      }
 
       Sint16 xlPos = _get_axis_value(controller, PAD_AXIS_LEFT_X_POS);
       Sint16 xlNeg = _get_axis_value(controller, PAD_AXIS_LEFT_X_NEG);

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -485,7 +485,7 @@ uint32_t PADRead(PADStatus* status) {
       
       for (const auto& mapping : kExtButtonMappings) {
         if (SDL_GetGamepadButton(controller->m_controller, mapping.first)) {
-          status[i].extButtons |= mapping.second;
+          status[i].extButton |= mapping.second;
         }
       }
 

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -1303,5 +1303,5 @@ PADBatteryState PADGetBatteryState(u32 port, f32* perc) {
   int tmp = 0;
   const auto ret = SDL_GetGamepadPowerInfo(ctrl->m_controller, &tmp);
   *perc = tmp / 100.f;
-  return static_cast<PADBatteryState>(tmp);
+  return static_cast<PADBatteryState>(ret);
 }

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -1302,6 +1302,10 @@ PADBatteryState PADGetBatteryState(u32 port, f32* perc) {
   
   int tmp = 0;
   const auto ret = SDL_GetGamepadPowerInfo(ctrl->m_controller, &tmp);
-  *perc = tmp / 100.f;
+  if (tmp != -1) {
+    *perc = static_cast<float>(tmp) / 100.f;
+  } else {
+    *perc = static_cast<float>(tmp);
+  }
   return static_cast<PADBatteryState>(ret);
 }

--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -1293,3 +1293,15 @@ BOOL PADIsGCAdapter(u32 port) {
   }
   return ctrl->m_isGameCube;
 }
+
+PADBatteryState PADGetBatteryState(u32 port, f32* perc) {
+  const auto* ctrl = aurora::input::get_controller_for_player(port);
+  if (ctrl == nullptr) {
+    return PAD_BATTERYSTATE_ERROR;
+  }
+  
+  int tmp = 0;
+  const auto ret = SDL_GetGamepadPowerInfo(ctrl->m_controller, &tmp);
+  *perc = tmp / 100.f;
+  return static_cast<PADBatteryState>(tmp);
+}


### PR DESCRIPTION
This adds a new field to PADStatus and a new function:

`u32 extButton`
and
`PADBatteryState PADGetBatteryState(u32 port, f32* perc)`

With these we're now able to query every button on the controller, I've organized the new button flags to not collide with the originals even though they're in a new field to prevent visual confusion.