### PR TITLE
added support for symlinks in linux

### DIFF
--- a/lib/gfx/texture_replacement.cpp
+++ b/lib/gfx/texture_replacement.cpp
@@ -486,7 +486,8 @@ void build_index() noexcept {
 
   std::error_code ec;
   for (std::filesystem::recursive_directory_iterator it(s_replacementRoot,
-                                                        std::filesystem::directory_options::skip_permission_denied, ec);
+                                                        std::filesystem::directory_options::skip_permission_denied |
+                                                        std::filesystem::directory_options::follow_directory_symlink, ec);
        it != std::filesystem::recursive_directory_iterator(); it.increment(ec)) {
     if (ec) {
       break;


### PR DESCRIPTION
Added the possibility to use a symbolic link to the replacement textures instead of the textures themselves. This is useful for people who have a partition setup with a dedicated $HOME directory and little space in said partition.

The change was minimal, requiring only adding one flag to the `recursive_directory_iterator` function in `texture_replacement.cpp`.

Tested it with [Dusk](https://github.com/TwilitRealm/dusk) and the [Twilight Princess 4K texture pack project](https://www.henrikomagnifico.com/zelda-twilight-princess-4k), it works fine.

I haven't tested it in other platforms, but since it's literally a C++ `std::` function, I'm assuming it's sure to work in MacOS and likely in Windows.