### PR TITLE
docs: add build instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ implementation used is Chromium's [Dawn](https://dawn.googlesource.com/dawn/).
 To build Aurora's included examples:
 
 ```bash
-git clone --recursive https://github.com/encounter/aurora.git
+git clone https://github.com/encounter/aurora.git
 cd aurora
 mkdir build && cd build
 cmake ..
@@ -93,6 +93,7 @@ See [examples/simple.c](examples/simple.c) for a minimal application template.
 - `AURORA_ENABLE_DVD` (default: OFF) - Enable DVD implementation backed by nod
 - `AURORA_ENABLE_CARD` (default: ON) - Enable CARD implementation based on kabufuda
 - `AURORA_ENABLE_RMLUI` (default: OFF) - Enable HTML/CSS based UI library
+- `AURORA_CACHE_USE_ZSTD` (default: ON) - Compress WebGPU cache entries with zstd
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,62 @@ implementation used is Chromium's [Dawn](https://dawn.googlesource.com/dawn/).
 
 ![Screenshot](assets/screenshot.png)
 
+### Building
+
+#### Prerequisites
+
+- CMake 3.25 or later
+- A C++20 compatible compiler (Clang, GCC, or MSVC)
+- Git (for cloning)
+
+#### Building the Examples
+
+To build Aurora's included examples:
+
+```bash
+git clone --recursive https://github.com/encounter/aurora.git
+cd aurora
+mkdir build && cd build
+cmake ..
+cmake --build . --target simple
+```
+
+The `simple` example demonstrates a minimal Aurora application with a blue screen. The built executable will be in `build/examples/simple`.
+
+#### Using Aurora in Your Project
+
+Aurora is designed to be integrated as a library in GameCube/Wii decompilation projects.
+
+**CMakeLists.txt example:**
+
+```cmake
+cmake_minimum_required(VERSION 3.25)
+project(your_game)
+
+# Add Aurora as a subdirectory
+add_subdirectory(extern/aurora EXCLUDE_FROM_ALL)
+
+# Create your executable
+add_executable(your_game src/main.c)
+
+# Link against Aurora components
+target_link_libraries(your_game PRIVATE 
+    aurora::core 
+    aurora::gx 
+    aurora::main 
+    aurora::vi
+)
+```
+
+See [examples/simple.c](examples/simple.c) for a minimal application template.
+
+#### CMake Options
+
+- `AURORA_ENABLE_GX` (default: ON) - Enable GX implementation and WebGPU renderer
+- `AURORA_ENABLE_DVD` (default: OFF) - Enable DVD implementation backed by nod
+- `AURORA_ENABLE_CARD` (default: ON) - Enable CARD implementation based on kabufuda
+- `AURORA_ENABLE_RMLUI` (default: OFF) - Enable HTML/CSS based UI library
+
 ### License
 
 Aurora is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -40,60 +40,7 @@ implementation used is Chromium's [Dawn](https://dawn.googlesource.com/dawn/).
 
 ### Building
 
-#### Prerequisites
-
-- CMake 3.25 or later
-- A C++20 compatible compiler (Clang, GCC, or MSVC)
-- Git (for cloning)
-
-#### Building the Examples
-
-To build Aurora's included examples:
-
-```bash
-git clone https://github.com/encounter/aurora.git
-cd aurora
-mkdir build && cd build
-cmake ..
-cmake --build . --target simple
-```
-
-The `simple` example demonstrates a minimal Aurora application with a blue screen. The built executable will be in `build/examples/simple`.
-
-#### Using Aurora in Your Project
-
-Aurora is designed to be integrated as a library in GameCube/Wii decompilation projects.
-
-**CMakeLists.txt example:**
-
-```cmake
-cmake_minimum_required(VERSION 3.25)
-project(your_game)
-
-# Add Aurora as a subdirectory
-add_subdirectory(extern/aurora EXCLUDE_FROM_ALL)
-
-# Create your executable
-add_executable(your_game src/main.c)
-
-# Link against Aurora components
-target_link_libraries(your_game PRIVATE 
-    aurora::core 
-    aurora::gx 
-    aurora::main 
-    aurora::vi
-)
-```
-
-See [examples/simple.c](examples/simple.c) for a minimal application template.
-
-#### CMake Options
-
-- `AURORA_ENABLE_GX` (default: ON) - Enable GX implementation and WebGPU renderer
-- `AURORA_ENABLE_DVD` (default: OFF) - Enable DVD implementation backed by nod
-- `AURORA_ENABLE_CARD` (default: ON) - Enable CARD implementation based on kabufuda
-- `AURORA_ENABLE_RMLUI` (default: OFF) - Enable HTML/CSS based UI library
-- `AURORA_CACHE_USE_ZSTD` (default: ON) - Compress WebGPU cache entries with zstd
+See [docs/building.md](docs/building.md) for build instructions, CMake integration, and configuration options.
 
 ### License
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,56 @@
+# Building
+
+## Prerequisites
+
+- CMake 3.25 or later
+- A C++20 compatible compiler (Clang, GCC, or MSVC)
+- Git (for cloning)
+
+## Building the Examples
+
+To build Aurora's included examples:
+
+```bash
+git clone https://github.com/encounter/aurora.git
+cd aurora
+mkdir build && cd build
+cmake ..
+cmake --build . --target simple
+```
+
+The `simple` example demonstrates a minimal Aurora application with a blue screen. The built executable will be in `build/examples/simple`.
+
+## Using Aurora in Your Project
+
+Aurora is designed to be integrated as a library in GameCube/Wii decompilation projects.
+
+**CMakeLists.txt example:**
+
+```cmake
+cmake_minimum_required(VERSION 3.25)
+project(your_game)
+
+# Add Aurora as a subdirectory
+add_subdirectory(extern/aurora EXCLUDE_FROM_ALL)
+
+# Create your executable
+add_executable(your_game src/main.c)
+
+# Link against Aurora components
+target_link_libraries(your_game PRIVATE 
+    aurora::core 
+    aurora::gx 
+    aurora::main 
+    aurora::vi
+)
+```
+
+See [examples/simple.c](../examples/simple.c) for a minimal application template.
+
+## CMake Options
+
+- `AURORA_ENABLE_GX` (default: ON) - Enable GX implementation and WebGPU renderer
+- `AURORA_ENABLE_DVD` (default: OFF) - Enable DVD implementation backed by nod
+- `AURORA_ENABLE_CARD` (default: ON) - Enable CARD implementation based on kabufuda
+- `AURORA_ENABLE_RMLUI` (default: OFF) - Enable HTML/CSS based UI library
+- `AURORA_CACHE_USE_ZSTD` (default: ON) - Compress WebGPU cache entries with zstd


### PR DESCRIPTION
## Summary

- Add comprehensive build documentation to README
- Prerequisites: CMake 3.25+, C++20 compiler
- Instructions for building included examples and integrating Aurora into game decomp projects
- Available CMake options including `AURORA_CACHE_USE_ZSTD`
- Verified on macOS with clang by building the simple example

Fixes #7

## Test plan

- [x] Build verified on macOS with clang (simple example compiles and runs)
- [x] No `--recursive` flag (no submodules; deps use FetchContent)
- [x] All documented CMake options verified against CMakeLists.txt