### PR TITLE
Fix vertex decoder for GX_NRM_NBT and GX_NRM_NBT3

### DIFF
--- a/lib/gx/command_processor.cpp
+++ b/lib/gx/command_processor.cpp
@@ -1181,7 +1181,10 @@ static void handle_cp(u8 addr, u32 value, bool bigEndian) {
       vf.attrs[GX_VA_POS].cnt = static_cast<GXCompCnt>(bp_get(value, 1, 0));
       vf.attrs[GX_VA_POS].type = static_cast<GXCompType>(bp_get(value, 3, 1));
       vf.attrs[GX_VA_POS].frac = static_cast<u8>(bp_get(value, 5, 4));
-      vf.attrs[GX_VA_NRM].cnt = static_cast<GXCompCnt>(bp_get(value, 1, 9));
+      const auto nrm_cnt = bp_get(value, 1, 9);
+      const auto nrm_nbt3 = bp_get(value, 1, 31);
+      vf.attrs[GX_VA_NRM].cnt = static_cast<GXCompCnt>(
+          nrm_nbt3 ? GX_NRM_NBT3 : (nrm_cnt ? GX_NRM_NBT : GX_NRM_XYZ));
       vf.attrs[GX_VA_NRM].type = static_cast<GXCompType>(bp_get(value, 3, 10));
       if (vf.attrs[GX_VA_NRM].type == GX_U8 || vf.attrs[GX_VA_NRM].type == GX_S8) {
         vf.attrs[GX_VA_NRM].frac = 6;

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -684,6 +684,9 @@ u8 comp_cnt_count(GXAttr attr, GXCompCnt cnt) noexcept {
     switch (cnt) {
     case GX_NRM_XYZ:
       return 3;
+    case GX_NRM_NBT:
+    case GX_NRM_NBT3:
+      return 9;
     default:
       break;
     }


### PR DESCRIPTION
Partial fix for #93. This fixes a couple decode-side issues: comp_cnt_count fatals on GX_NRM_NBT/NBT3, and VAT-A decoding was collapsing NBT3 back into NBT because it only checked bit 9 and ignored the bit-31 escape.

 > **Update:** scratch the bit below — since I'm already in the area, I'm going to address the shader-generator side in this PR too rather than leaving a follow-up. New commits incoming.

The shader generator still assumes a single vec3 normal, so binormal/tangent data is currently read from the FIFO and dropped before reaching the shader. I’m still getting familiar with Aurora, and that part feels a lot broader in scope than this decode fix, so I’d rather tackle it in a follow-up PR after I’ve spent more time in the shader and WebGPU vertex buffer code.