### PR TITLE
Don't crash loading unsupported texture replacements

### DIFF
--- a/lib/gfx/texture_replacement.cpp
+++ b/lib/gfx/texture_replacement.cpp
@@ -388,12 +388,42 @@ static std::optional<ConvertedTexture> load_texture_file(const std::filesystem::
   }
 }
 
+constexpr bool isUnsupportedTextureFormat(const ConvertedTexture& texture) {
+  switch (texture.format) {
+  case wgpu::TextureFormat::BC1RGBAUnorm:
+  case wgpu::TextureFormat::BC1RGBAUnormSrgb:
+  case wgpu::TextureFormat::BC2RGBAUnorm:
+  case wgpu::TextureFormat::BC2RGBAUnormSrgb:
+  case wgpu::TextureFormat::BC3RGBAUnorm:
+  case wgpu::TextureFormat::BC3RGBAUnormSrgb:
+  case wgpu::TextureFormat::BC4RUnorm:
+  case wgpu::TextureFormat::BC4RSnorm:
+  case wgpu::TextureFormat::BC5RGUnorm:
+  case wgpu::TextureFormat::BC5RGSnorm:
+  case wgpu::TextureFormat::BC6HRGBUfloat:
+  case wgpu::TextureFormat::BC6HRGBFloat:
+  case wgpu::TextureFormat::BC7RGBAUnorm:
+  case wgpu::TextureFormat::BC7RGBAUnormSrgb:
+    return !webgpu::g_bcTexturesSupported;
+  default:
+    return false;
+  }
+}
+
 std::optional<ConvertedTexture> load_replacement(const ReplacementIndexEntry& entry) noexcept {
   auto base = load_texture_file(entry.path);
   if (!base.has_value()) {
     Log.warn("texture_replacement: failed to load texture {}", fs_path_to_string(entry.path));
     return std::nullopt;
   }
+  if (isUnsupportedTextureFormat(base.value())) {
+    Log.warn(
+      "texture_replacement: failed to load texture {} due to unsupported format: {}",
+      fs_path_to_string(entry.path),
+      static_cast<uint32_t>(base->format));
+    return std::nullopt;
+  }
+
   if (!entry.hasMips) {
     return base;
   }

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -48,6 +48,7 @@ static wgpu::Adapter g_adapter;
 wgpu::Instance g_instance;
 static wgpu::AdapterInfo g_adapterInfo;
 static wgpu::SurfaceCapabilities g_surfaceCapabilities;
+bool g_bcTexturesSupported;
 
 namespace {
 
@@ -516,6 +517,7 @@ bool initialize(AuroraBackend auroraBackend) {
     for (size_t i = 0; i < supportedFeatures.featureCount; ++i) {
       const auto feature = supportedFeatures.features[i];
       if (feature == wgpu::FeatureName::TextureCompressionBC) {
+        g_bcTexturesSupported = true;
         requiredFeatures.push_back(feature);
       }
     }

--- a/lib/webgpu/gpu.hpp
+++ b/lib/webgpu/gpu.hpp
@@ -50,6 +50,7 @@ extern TextureWithSampler g_depthBuffer;
 extern wgpu::RenderPipeline g_CopyPipeline;
 extern wgpu::BindGroup g_CopyBindGroup;
 extern wgpu::Instance g_instance;
+extern bool g_bcTexturesSupported;
 
 bool initialize(AuroraBackend backend);
 void shutdown();


### PR DESCRIPTION
So people stop getting crashes from BC textures on Android and iOS.