### PR TITLE
Always display replacement mips and use Linear filter mode on texture replacements

### DIFF
--- a/lib/gfx/texture.hpp
+++ b/lib/gfx/texture.hpp
@@ -35,6 +35,7 @@ struct TextureRef {
   uint32_t mipCount;
   u32 gxFormat;
   bool hasArbitraryMips = false;
+  bool isReplacement = false;
 
   TextureRef(wgpu::Texture texture, wgpu::TextureView sampleTextureView, wgpu::TextureView attachmentTextureView,
              wgpu::Extent3D size, wgpu::TextureFormat format, uint32_t mipCount, u32 gxFormat)

--- a/lib/gfx/texture_replacement.cpp
+++ b/lib/gfx/texture_replacement.cpp
@@ -62,7 +62,6 @@ struct CachedReplacement {
 
 struct ReplacementIndexEntry {
   std::filesystem::path path;
-  bool hasMips;
 };
 
 absl::flat_hash_map<RuntimeTextureKey, ReplacementIndexEntry> s_replacementIndex;
@@ -284,7 +283,7 @@ std::string format_replacement_filename(const RuntimeTextureKey& key) {
   return fmt::format("tex1_{}x{}_{:016x}_{}.dds", key.width, key.height, key.textureHash, key.format);
 }
 
-std::optional<std::pair<RuntimeTextureKey, bool>> parse_replacement_filename(std::string_view filename) noexcept {
+std::optional<RuntimeTextureKey> parse_replacement_filename(std::string_view filename) noexcept {
   const size_t dot = filename.rfind('.');
   if (dot == std::string_view::npos) {
     return std::nullopt;
@@ -323,9 +322,7 @@ std::optional<std::pair<RuntimeTextureKey, bool>> parse_replacement_filename(std
   }
 
   size_t index = 2;
-  bool hasMips = false;
   if (parts[index] == "m") {
-    hasMips = true;
     ++index;
   }
 
@@ -370,7 +367,7 @@ std::optional<std::pair<RuntimeTextureKey, bool>> parse_replacement_filename(std
     }
   }
 
-  RuntimeTextureKey key{
+  return RuntimeTextureKey{
       .textureHash = textureHash,
       .tlutHash = tlutHash,
       .width = dimensions->first,
@@ -378,7 +375,6 @@ std::optional<std::pair<RuntimeTextureKey, bool>> parse_replacement_filename(std
       .hasTlut = hasTlut,
       .format = *format,
   };
-  return {{key, hasMips}};
 }
 
 static std::optional<ConvertedTexture> load_texture_file(const std::filesystem::path& path) {
@@ -425,10 +421,6 @@ std::optional<ConvertedTexture> load_replacement(const ReplacementIndexEntry& en
     return std::nullopt;
   }
 
-  if (!entry.hasMips) {
-    return base;
-  }
-
   std::vector<ConvertedTexture> more;
   std::error_code ec;
   for (uint32_t mipLevel = 1;; ++mipLevel) {
@@ -455,7 +447,7 @@ std::optional<ConvertedTexture> load_replacement(const ReplacementIndexEntry& en
   }
 
   if (more.empty()) {
-    return std::nullopt;
+    return base;
   }
 
   const uint32_t mips = 1u + static_cast<uint32_t>(more.size());
@@ -571,7 +563,7 @@ void build_index() noexcept {
       continue;
     }
 
-    s_replacementIndex.try_emplace(parsed->first, path, parsed->second);
+    s_replacementIndex.try_emplace(*parsed, path);
   }
 
   Log.info("Indexed {} texture replacements", s_replacementIndex.size());
@@ -642,6 +634,7 @@ gfx::TextureHandle load_replacement_texture(const RuntimeTextureKey& key, const 
   auto textureView = texture.CreateView(&textureViewDescriptor);
   auto handle = std::make_shared<gfx::TextureRef>(std::move(texture), std::move(textureView), wgpu::TextureView{}, size,
                                                   replacement->format, replacement->mips, gfx::InvalidTextureFormat);
+  handle->isReplacement = true;
   gfx::write_texture(*handle, replacement->data);
   return handle;
 }
@@ -654,15 +647,6 @@ void cache_replacement(const RuntimeTextureKey& key, const gfx::TextureHandle& h
       key, CachedReplacement{.handle = handle, .bytes = replacementBytes, .lruIt = s_replacementLru.begin()});
   s_replacementCacheBytes += replacementBytes;
   evict_replacement_cache_if_needed();
-}
-
-void bind_replacement(GXTexObj_& obj, GXTexMapID id, const gfx::TextureHandle& handle) noexcept {
-  GXTexObj_ out = obj;
-  out.mWidth = handle->size.width;
-  out.mHeight = handle->size.height;
-  out.mFormat = GX_TF_RGBA8_PC;
-  g_gxState.textures[id] = gfx::TextureBind(out, handle);
-  g_gxState.stateDirty = true;
 }
 
 bool dump_editable_texture_dds(const RuntimeTextureKey& key, const GXTexObj_& obj) noexcept {
@@ -757,19 +741,6 @@ void load_tlut(const GXTlutObj* obj, uint32_t idx) noexcept {
       .valid = pending.valid,
       .data = pending.data.clone(),
   };
-}
-
-bool try_bind_replacement(GXTexObj_& obj, GXTexMapID id) noexcept {
-  if (!g_config.allowTextureReplacements) {
-    return false;
-  }
-
-  const auto handle = find_replacement(obj);
-  if (!handle.has_value()) {
-    return false;
-  }
-  bind_replacement(obj, id, *handle);
-  return true;
 }
 
 std::optional<TextureHandle> find_replacement(const GXTexObj_& obj) noexcept {

--- a/lib/gfx/texture_replacement.hpp
+++ b/lib/gfx/texture_replacement.hpp
@@ -10,5 +10,4 @@ void register_tlut(const GXTlutObj* obj, const void* data, GXTlutFmt format, uin
 void load_tlut(const GXTlutObj* obj, uint32_t idx) noexcept;
 std::optional<TextureHandle> find_replacement(const GXTexObj_& obj) noexcept;
 std::string build_texture_replacement_name(const GXTexObj_& obj) noexcept;
-bool try_bind_replacement(GXTexObj_& obj, GXTexMapID id) noexcept;
 } // namespace aurora::gfx::texture_replacement

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -985,11 +985,16 @@ static u16 wgpu_aniso(GXAnisotropy aniso) {
 }
 
 wgpu::SamplerDescriptor aurora::gfx::TextureBind::get_descriptor() const noexcept {
-  const auto [minFilter, mipFilter] = wgpu_filter_mode(texObj.min_filter());
+  auto [minFilter, mipFilter] = wgpu_filter_mode(texObj.min_filter());
   const auto [magFilter, _] = wgpu_filter_mode(texObj.mag_filter());
   float minLod = texObj.min_lod();
   float maxLod = texObj.max_lod();
-  if (mipFilter == wgpu::MipmapFilterMode::Undefined) {
+  if (ref && ref->isReplacement) {
+    minFilter = wgpu::FilterMode::Linear;
+    mipFilter = wgpu::MipmapFilterMode::Linear;
+    minLod = 0.f;
+    maxLod = static_cast<float>(std::max(ref->mipCount, 1u) - 1u);
+  } else if (mipFilter == wgpu::MipmapFilterMode::Undefined) {
     minLod = 0.f;
     maxLod = 0.f;
   }

--- a/tests/gx_test_stubs.cpp
+++ b/tests/gx_test_stubs.cpp
@@ -243,7 +243,6 @@ u32 compute_texture_upload_size(const GXTexObj_& obj) noexcept { return 0; }
 void register_tlut(const GXTlutObj*, const void*, GXTlutFmt, u16) noexcept {}
 void load_tlut(const GXTlutObj*, u32) noexcept {}
 std::optional<TextureHandle> find_replacement(const GXTexObj_&) noexcept { return std::nullopt; }
-bool try_bind_replacement(GXTexObj_&, GXTexMapID) noexcept { return false; }
 } // namespace aurora::gfx::texture_replacement
 
 // --- Window stub ---


### PR DESCRIPTION
This removes the old hasMips logic in exchange for always using mips (and setting the respective filter modes) if a replacement texture provides them, instead of only when the texture has `_m` in its filename. This matches Dolphin's handling.

Comparison screenshots below in the following order from top to bottom:
- Dolphin
- Aurora, after this PR
- Aurora, before this PR

<details>
<summary>5x IR and no AF</summary>
<img width="2560" height="1392" alt="Dolphin" src="https://github.com/user-attachments/assets/1096843f-aa6b-4403-9a19-cde72bf4913a" />
<img width="2560" height="1440" alt="Aurora, after this PR" src="https://github.com/user-attachments/assets/861a54c1-a74f-438b-98c4-e9147f0dceb0" />
<img width="2560" height="1440" alt="Aurora, before this PR" src="https://github.com/user-attachments/assets/b04dfd87-edf7-4648-b647-6d95330825d5" />
</details>

<details>
<summary>5x IR and x16 AF (forced through Nvidia's driver for Aurora)</summary>
<img width="2560" height="1392" alt="Dolphin" src="https://github.com/user-attachments/assets/625fa4cc-290d-40f4-9112-85061e16e69d" />
<img width="2560" height="1440" alt="Aurora, after this PR" src="https://github.com/user-attachments/assets/18bbe69b-a5a3-403a-8dc0-3a2df19c6a40" />
<img width="2560" height="1440" alt="Aurora, before this PR" src="https://github.com/user-attachments/assets/2fa49470-bee8-4ea7-be6a-d0a69b425ed3" />
</details>