### PR TITLE
Make digital shoulder buttons properly set analog value

### DIFF
--- a/lib/dolphin/pad/pad.cpp
+++ b/lib/dolphin/pad/pad.cpp
@@ -799,6 +799,14 @@ u32 PADRead(PADStatus* status) {
       status[i].triggerLeft = static_cast<int8_t>(tl);
       status[i].triggerRight = static_cast<int8_t>(tr);
 
+      // If the digital button is activated, set the analog value to max.
+      if (status[i].button & PAD_TRIGGER_L) {
+        status[i].triggerLeft = 180;
+      }
+      if (status[i].button & PAD_TRIGGER_R) {
+        status[i].triggerRight = 180;
+      }
+
       if (controller->m_hasRumble) {
         rumbleSupport |= PAD_CHAN0_BIT >> i;
       }


### PR DESCRIPTION
If a digital shoulder button is pressed, set the analog value to 180.
Without this, pressing the digital shoulder buttons do nothing in games that look exclusively for analog value, and additionally the trigger thresholds do not function as they should.
This closes both these issues.