### PR TITLE
Add method to enable/disable textures and reload once changed.

### DIFF
--- a/include/aurora/gfx.h
+++ b/include/aurora/gfx.h
@@ -31,6 +31,8 @@ typedef struct {
 const AuroraStats* aurora_get_stats();
 
 void aurora_enable_vsync(bool enabled);
+void aurora_set_texture_replacements_enabled(bool enabled);
+void aurora_reload_texture_replacements();
 
 #ifdef __cplusplus
 }

--- a/lib/gfx/common.cpp
+++ b/lib/gfx/common.cpp
@@ -1089,3 +1089,10 @@ void pop_debug_group() {
 }
 
 const AuroraStats* aurora_get_stats() { return &aurora::gfx::g_stats; }
+
+void aurora_set_texture_replacements_enabled(const bool enabled) {
+  aurora::g_config.allowTextureReplacements = enabled;
+  aurora::gfx::texture_replacement::reload();
+}
+
+void aurora_reload_texture_replacements() { aurora::gfx::texture_replacement::reload(); }

--- a/lib/gfx/texture_replacement.cpp
+++ b/lib/gfx/texture_replacement.cpp
@@ -703,21 +703,31 @@ bool report_missing_key(const RuntimeTextureKey& key, const GXTexObj_& obj) noex
   return true;
 }
 
-void initialize() noexcept { build_index(); }
-
-void shutdown() noexcept {
+void clear_replacement_runtime_state() noexcept {
   s_replacementIndex.clear();
   s_replacementCache.clear();
   s_failedKeys.clear();
   s_reportedMisses.clear();
-  s_pendingTluts.clear();
-  for (auto& tlut : s_loadedTluts) {
-    tlut = {};
-  }
   s_replacementLru.clear();
   s_replacementCacheBytes = 0;
   s_replacementRoot.clear();
   s_dumpRoot.clear();
+}
+
+void initialize() noexcept { build_index(); }
+
+void reload() noexcept {
+  clear_replacement_runtime_state();
+  aurora::gx::clear_static_texture_cache();
+  build_index();
+}
+
+void shutdown() noexcept {
+  clear_replacement_runtime_state();
+  s_pendingTluts.clear();
+  for (auto& tlut : s_loadedTluts) {
+    tlut = {};
+  }
 }
 
 void register_tlut(const GXTlutObj* obj, const void* data, GXTlutFmt format, uint16_t entries) noexcept {

--- a/lib/gfx/texture_replacement.hpp
+++ b/lib/gfx/texture_replacement.hpp
@@ -6,6 +6,7 @@
 namespace aurora::gfx::texture_replacement {
 void initialize() noexcept;
 void shutdown() noexcept;
+void reload() noexcept;
 void register_tlut(const GXTlutObj* obj, const void* data, GXTlutFmt format, uint16_t entries) noexcept;
 void load_tlut(const GXTlutObj* obj, uint32_t idx) noexcept;
 std::optional<TextureHandle> find_replacement(const GXTexObj_& obj) noexcept;

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -369,6 +369,13 @@ void clear_copy_texture_cache() noexcept {
   }
 }
 
+void clear_static_texture_cache() noexcept {
+  s_textureObjectCaches.clear();
+  for (auto& [_, cache] : s_tlutObjectCaches) {
+    cache.staticTextureUsers.clear();
+  }
+}
+
 void evict_copy_texture(const void* dest) noexcept {
   g_gxState.copyTextures.erase(dest);
   for (auto it = g_gxState.copyTextureCache.begin(); it != g_gxState.copyTextureCache.end();) {

--- a/lib/gx/gx.hpp
+++ b/lib/gx/gx.hpp
@@ -387,6 +387,7 @@ struct ShaderInfo;
 
 void initialize() noexcept;
 void shutdown() noexcept;
+void clear_static_texture_cache() noexcept;
 void clear_copy_texture_cache() noexcept;
 void evict_copy_texture(const void* dest) noexcept;
 void evict_texture_object(u32 texObjId) noexcept;


### PR DESCRIPTION
I wanted to add a little helper to allow a project to enable/disable texture replacements and then reload and rebuild the replacements. I'm also putting in a pull request to dusk to add an option to change the texture replacement state