### PR TITLE
Revert "Use mipmaps from .dds file if present"

### DIFF
--- a/lib/gfx/dds_io.cpp
+++ b/lib/gfx/dds_io.cpp
@@ -197,7 +197,7 @@ std::optional<ConvertedTexture> parse_dds_bytes(ArrayRef<uint8_t> bytes) noexcep
     return std::nullopt;
   }
 
-  const uint32_t mipCount = header->mipMapCount;
+  const uint32_t mipCount = 1u;
   const auto expectedSize = calc_texture_size(parsedLayout->format, header->width, header->height, mipCount);
   if (expectedSize == 0 || parsedLayout->dataOffset + expectedSize > bytes.size()) {
     return std::nullopt;

--- a/lib/gfx/texture_replacement.cpp
+++ b/lib/gfx/texture_replacement.cpp
@@ -421,11 +421,6 @@ std::optional<ConvertedTexture> load_replacement(const ReplacementIndexEntry& en
     return std::nullopt;
   }
 
-  if (base->mips > 1)
-  {
-    return base;
-  }
-
   std::vector<ConvertedTexture> more;
   std::error_code ec;
   for (uint32_t mipLevel = 1;; ++mipLevel) {


### PR DESCRIPTION
Reverts encounter/aurora#194.

Trevor broke sidecar mips by doing that, which is the far more common path given our Dolphin compatibility.