### PR TITLE
Revert "set window coord as UNDEFINED only if x||y==-1"

### DIFF
--- a/lib/window.cpp
+++ b/lib/window.cpp
@@ -295,6 +295,11 @@ bool create_window(AuroraBackend backend) {
 
   Sint32 posX = g_config.windowPosX;
   Sint32 posY = g_config.windowPosY;
+  if (posX < 0 || posY < 0) {
+    posX = SDL_WINDOWPOS_UNDEFINED;
+    posY = SDL_WINDOWPOS_UNDEFINED;
+  }
+
   const auto props = SDL_CreateProperties();
   TRY(SDL_SetStringProperty(props, SDL_PROP_WINDOW_CREATE_TITLE_STRING, g_config.appName), "Failed to set {}: {}",
       SDL_PROP_WINDOW_CREATE_TITLE_STRING, SDL_GetError());


### PR DESCRIPTION
Reverts encounter/aurora#185

Completes a revert of https://github.com/TwilitRealm/dusklight/pull/1558, which is bugged and breaks the ability to toggle fullscreen. Without Aurora's side reverted, the window is moved to 0x0 instead of the center of your monitor.