### PR TITLE
Make pipeline cache preload opt-in

### DIFF
--- a/include/aurora/aurora.h
+++ b/include/aurora/aurora.h
@@ -92,6 +92,7 @@ typedef struct {
   bool pauseOnFocusLost;
   bool allowTextureReplacements;
   bool allowTextureDumps;
+  bool preloadPipelineCache;
   int32_t windowPosX;
   int32_t windowPosY;
   uint32_t windowWidth;

--- a/lib/gfx/pipeline_cache.cpp
+++ b/lib/gfx/pipeline_cache.cpp
@@ -11,6 +11,7 @@
 #include <deque>
 #include <filesystem>
 #include <mutex>
+#include <optional>
 #include <thread>
 
 #include <absl/container/flat_hash_map.h>
@@ -601,7 +602,11 @@ void initialize_pipeline_cache() {
     g_pipelineThread = std::thread(pipeline_worker);
   }
 
-  load_pipeline_cache();
+  if (g_config.preloadPipelineCache) {
+    load_pipeline_cache();
+  } else {
+    prune_old_pipeline_cache_versions();
+  }
   if (!g_pipelineCacheBroken) {
     start_pipeline_cache_writer();
   }


### PR DESCRIPTION
This makes cached pipeline preloading opt-in through AuroraConfig, partially addressing #100 

In Dusk testing, startup was eagerly queueing hundreds of cached pipelines for compilation, which caused unnecessary startup work and memory pressure. This keeps the cache database and normal on-demand pipeline creation, but avoids compiling the whole cache at startup unless the app explicitly enables it.