### PR TITLE
Allow AURORA_GFX_DEBUG_GROUPS to be set from CMake individually

### DIFF
--- a/include/aurora/gfx.h
+++ b/include/aurora/gfx.h
@@ -9,7 +9,7 @@ extern "C" {
 #include "stdint.h"
 #endif
 
-#ifndef NDEBUG
+#if !defined(NDEBUG) && !defined(AURORA_GFX_DEBUG_GROUPS)
 #define AURORA_GFX_DEBUG_GROUPS
 #endif
 


### PR DESCRIPTION
So that I can do target_compile_definitions(aurora_gx PRIVATE AURORA_GFX_DEBUG_GROUPS) instead of needing to enable DEBUG