### PR TITLE
Add stencil support for aurora

### DIFF
--- a/include/dolphin/gx/GXAurora.h
+++ b/include/dolphin/gx/GXAurora.h
@@ -2,6 +2,7 @@
 #define DOLPHIN_GXAURORA_H
 
 #include <dolphin/types.h>
+#include <dolphin/gx/GXEnum.h>
 
 #if __cplusplus
 extern "C" {
@@ -80,6 +81,22 @@ extern "C" {
 
 #define GX2_SET_POLYGON_OFFSET 0x1000
 
+/**
+ * GX2SetStencilMask: compare masks, write masks and reference values for both faces.
+ * Must be followed by six u8 values: pre_mask_front, write_mask_front, ref_front,
+ * pre_mask_back, write_mask_back, ref_back. (Aurora uses the front-face values.)
+ */
+#define GX2_SET_STENCIL_MASK 0x1001
+
+/**
+ * GX2SetDepthStencilControl: depth test/write/func + stencil enable/funcs/ops, one register.
+ * Must be followed by thirteen u8 values: depth_test, depth_write, depth_func (GXCompare),
+ * stencil_test, back_stencil_enable, front_func (GXCompare), front_zpass, front_zfail, front_fail
+ * (GXStencilOp), back_func, back_zpass, back_zfail, back_fail. (Aurora uses the front face.)
+ * NOTE: like on GX2, any GXSetZMode (BP zmode) write also disables the stencil test.
+ */
+#define GX2_SET_DEPTH_STENCIL_CONTROL 0x1002
+
 
 /*
  * Debug marker stuff
@@ -131,6 +148,37 @@ void GXSetViewportRender(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz)
 void GXSetScissorRender(u32 left, u32 top, u32 wd, u32 ht);
 
 void GX2SetPolygonOffset(f32 mFrontOffset, f32 mFrontScale, f32 mBackOffset, f32 mBackScale, f32 mClamp);
+
+typedef enum GXStencilOp {
+  GX_ST_KEEP = 0,
+  GX_ST_ZERO = 1,
+  GX_ST_REPLACE = 2,
+  GX_ST_INCR = 3,
+  GX_ST_DECR = 4,
+  GX_ST_INVERT = 5,
+} GXStencilOp;
+
+/**
+ * GX2SetStencilMask analogue (compare/write masks + refs; front face used).
+ * u8 parameters so decompiled GX2 call sites transcribe verbatim.
+ */
+void GX2SetStencilMask(u8 pre_mask_front, u8 write_mask_front, u8 ref_front, u8 pre_mask_back,
+                       u8 write_mask_back, u8 ref_back);
+
+/**
+ * GX2SetDepthStencilControl analogue. depth_func/front_func take GXCompare values,
+ * the op parameters GXStencilOp values (both numerically identical to GX2 — decomp args are
+ * valid verbatim). A subsequent GXSetZMode write disables the stencil test, as on GX2.
+ */
+void GX2SetDepthStencilControl(u8 depth_test, u8 depth_write, u8 depth_func, u8 stencil_test,
+                               u8 back_stencil_enable, u8 front_func, u8 front_zpass,
+                               u8 front_zfail, u8 front_fail, u8 back_func, u8 back_zpass,
+                               u8 back_zfail, u8 back_fail);
+
+/**
+ * Returns whether the backend depth buffer carries a stencil aspect.
+ */
+GXBool GX2SupportsStencil(void);
 
 /**
  * Create an offscreen framebuffer and switch rendering to it.

--- a/include/dolphin/gx/GXAurora.h
+++ b/include/dolphin/gx/GXAurora.h
@@ -2,6 +2,7 @@
 #define DOLPHIN_GXAURORA_H
 
 #include <dolphin/types.h>
+#include <dolphin/gx/GXEnum.h>
 
 #if __cplusplus
 extern "C" {
@@ -98,6 +99,22 @@ extern "C" {
 
 #define GX2_SET_POLYGON_OFFSET 0x1000
 
+/**
+ * GX2SetStencilMask: compare masks, write masks and reference values for both faces.
+ * Must be followed by six u8 values: pre_mask_front, write_mask_front, ref_front,
+ * pre_mask_back, write_mask_back, ref_back. (Aurora uses the front-face values.)
+ */
+#define GX2_SET_STENCIL_MASK 0x1001
+
+/**
+ * GX2SetDepthStencilControl: depth test/write/func + stencil enable/funcs/ops, one register.
+ * Must be followed by thirteen u8 values: depth_test, depth_write, depth_func (GXCompare),
+ * stencil_test, back_stencil_enable, front_func (GXCompare), front_zpass, front_zfail, front_fail
+ * (GXStencilOp), back_func, back_zpass, back_zfail, back_fail. (Aurora uses the front face.)
+ * NOTE: like on GX2, any GXSetZMode (BP zmode) write also disables the stencil test.
+ */
+#define GX2_SET_DEPTH_STENCIL_CONTROL 0x1002
+
 
 /*
  * Debug marker stuff
@@ -149,6 +166,37 @@ void GXSetViewportRender(f32 left, f32 top, f32 wd, f32 ht, f32 nearz, f32 farz)
 void GXSetScissorRender(u32 left, u32 top, u32 wd, u32 ht);
 
 void GX2SetPolygonOffset(f32 mFrontOffset, f32 mFrontScale, f32 mBackOffset, f32 mBackScale, f32 mClamp);
+
+typedef enum GXStencilOp {
+  GX_ST_KEEP = 0,
+  GX_ST_ZERO = 1,
+  GX_ST_REPLACE = 2,
+  GX_ST_INCR = 3,
+  GX_ST_DECR = 4,
+  GX_ST_INVERT = 5,
+} GXStencilOp;
+
+/**
+ * GX2SetStencilMask analogue (compare/write masks + refs; front face used).
+ * u8 parameters so decompiled GX2 call sites transcribe verbatim.
+ */
+void GX2SetStencilMask(u8 pre_mask_front, u8 write_mask_front, u8 ref_front, u8 pre_mask_back,
+                       u8 write_mask_back, u8 ref_back);
+
+/**
+ * GX2SetDepthStencilControl analogue. depth_func/front_func take GXCompare values,
+ * the op parameters GXStencilOp values (both numerically identical to GX2 — decomp args are
+ * valid verbatim). A subsequent GXSetZMode write disables the stencil test, as on GX2.
+ */
+void GX2SetDepthStencilControl(u8 depth_test, u8 depth_write, u8 depth_func, u8 stencil_test,
+                               u8 back_stencil_enable, u8 front_func, u8 front_zpass,
+                               u8 front_zfail, u8 front_fail, u8 back_func, u8 back_zpass,
+                               u8 back_zfail, u8 back_fail);
+
+/**
+ * Returns whether the backend depth buffer carries a stencil aspect.
+ */
+GXBool GX2SupportsStencil(void);
 
 /**
  * Load an arbitrary 4x4 projection matrix, avoiding the 6-parameter hardware encoding.

--- a/lib/dolphin/gx/GXAurora.cpp
+++ b/lib/dolphin/gx/GXAurora.cpp
@@ -8,6 +8,7 @@
 
 #include "../../gfx/common.hpp"
 #include "../../gx/fifo.hpp"
+#include "../../webgpu/gpu.hpp"
 
 static void GXWriteString(const char* label) {
   auto length = strlen(label);
@@ -73,6 +74,41 @@ void GX2SetPolygonOffset(f32 mFrontOffset, f32 mFrontScale, f32 mBackOffset, f32
   GX_WRITE_F32(mBackOffset);
   GX_WRITE_F32(mBackScale);
   GX_WRITE_F32(mClamp);
+}
+
+void GX2SetStencilMask(u8 pre_mask_front, u8 write_mask_front, u8 ref_front, u8 pre_mask_back,
+                       u8 write_mask_back, u8 ref_back) {
+  GX_WRITE_AURORA(GX2_SET_STENCIL_MASK);
+  GX_WRITE_U8(pre_mask_front);
+  GX_WRITE_U8(write_mask_front);
+  GX_WRITE_U8(ref_front);
+  GX_WRITE_U8(pre_mask_back);
+  GX_WRITE_U8(write_mask_back);
+  GX_WRITE_U8(ref_back);
+}
+
+void GX2SetDepthStencilControl(u8 depth_test, u8 depth_write, u8 depth_func, u8 stencil_test,
+                               u8 back_stencil_enable, u8 front_func, u8 front_zpass,
+                               u8 front_zfail, u8 front_fail, u8 back_func, u8 back_zpass,
+                               u8 back_zfail, u8 back_fail) {
+  GX_WRITE_AURORA(GX2_SET_DEPTH_STENCIL_CONTROL);
+  GX_WRITE_U8(depth_test);
+  GX_WRITE_U8(depth_write);
+  GX_WRITE_U8(depth_func);
+  GX_WRITE_U8(stencil_test);
+  GX_WRITE_U8(back_stencil_enable);
+  GX_WRITE_U8(front_func);
+  GX_WRITE_U8(front_zpass);
+  GX_WRITE_U8(front_zfail);
+  GX_WRITE_U8(front_fail);
+  GX_WRITE_U8(back_func);
+  GX_WRITE_U8(back_zpass);
+  GX_WRITE_U8(back_zfail);
+  GX_WRITE_U8(back_fail);
+}
+
+GXBool GX2SupportsStencil(void) {
+  return aurora::webgpu::g_graphicsConfig.depthStencilSupported ? GX_TRUE : GX_FALSE;
 }
 
 void GXCreateFrameBuffer(u32 width, u32 height) {

--- a/lib/dolphin/gx/GXAurora.cpp
+++ b/lib/dolphin/gx/GXAurora.cpp
@@ -7,6 +7,7 @@
 #include "../../window.hpp"
 
 #include "../../gx/fifo.hpp"
+#include "../../webgpu/gpu.hpp"
 
 static void GXWriteString(const char* label) {
   auto length = strlen(label);
@@ -79,6 +80,41 @@ void GX2SetPolygonOffset(f32 mFrontOffset, f32 mFrontScale, f32 mBackOffset, f32
   GX_WRITE_F32(mBackOffset);
   GX_WRITE_F32(mBackScale);
   GX_WRITE_F32(mClamp);
+}
+
+void GX2SetStencilMask(u8 pre_mask_front, u8 write_mask_front, u8 ref_front, u8 pre_mask_back,
+                       u8 write_mask_back, u8 ref_back) {
+  GX_WRITE_AURORA(GX2_SET_STENCIL_MASK);
+  GX_WRITE_U8(pre_mask_front);
+  GX_WRITE_U8(write_mask_front);
+  GX_WRITE_U8(ref_front);
+  GX_WRITE_U8(pre_mask_back);
+  GX_WRITE_U8(write_mask_back);
+  GX_WRITE_U8(ref_back);
+}
+
+void GX2SetDepthStencilControl(u8 depth_test, u8 depth_write, u8 depth_func, u8 stencil_test,
+                               u8 back_stencil_enable, u8 front_func, u8 front_zpass,
+                               u8 front_zfail, u8 front_fail, u8 back_func, u8 back_zpass,
+                               u8 back_zfail, u8 back_fail) {
+  GX_WRITE_AURORA(GX2_SET_DEPTH_STENCIL_CONTROL);
+  GX_WRITE_U8(depth_test);
+  GX_WRITE_U8(depth_write);
+  GX_WRITE_U8(depth_func);
+  GX_WRITE_U8(stencil_test);
+  GX_WRITE_U8(back_stencil_enable);
+  GX_WRITE_U8(front_func);
+  GX_WRITE_U8(front_zpass);
+  GX_WRITE_U8(front_zfail);
+  GX_WRITE_U8(front_fail);
+  GX_WRITE_U8(back_func);
+  GX_WRITE_U8(back_zpass);
+  GX_WRITE_U8(back_zfail);
+  GX_WRITE_U8(back_fail);
+}
+
+GXBool GX2SupportsStencil(void) {
+  return aurora::webgpu::g_graphicsConfig.depthStencilSupported ? GX_TRUE : GX_FALSE;
 }
 
 void GXCreateFrameBuffer(u32 width, u32 height) {

--- a/lib/gfx/common.cpp
+++ b/lib/gfx/common.cpp
@@ -386,11 +386,11 @@ static void set_efb_targets(RenderPass& pass) {
       webgpu::g_graphicsConfig.msaaSamples > 1 ? webgpu::g_frameBufferResolved.texture : webgpu::g_frameBuffer.texture;
   pass.copySourceView =
       webgpu::g_graphicsConfig.msaaSamples > 1 ? webgpu::g_frameBufferResolved.view : webgpu::g_frameBuffer.view;
-  pass.copySourceDepthView = webgpu::g_depthBuffer.view;
+  pass.copySourceDepthView = webgpu::g_depthBuffer.sampleView;  
   pass.targetSize = webgpu::g_frameBuffer.size;
   pass.msaaSamples = webgpu::g_graphicsConfig.msaaSamples;
   pass.hasDepth = true;
-  pass.hasStencil = false;
+  pass.hasStencil = webgpu::g_graphicsConfig.depthStencilSupported;  
 }
 
 struct OffscreenCacheKey {
@@ -1440,10 +1440,13 @@ static void render(wgpu::CommandEncoder& cmd, FramePacket& frame, RenderPass& pa
                                                 : (passInfo.clearDepth ? wgpu::LoadOp::Clear : wgpu::LoadOp::Load))
                                          : wgpu::LoadOp::Undefined,
         .depthStoreOp = passInfo.hasDepth ? passInfo.depthStoreOp : wgpu::StoreOp::Undefined,
-        .depthClearValue = passInfo.clearDepthValue,
-        .stencilLoadOp = passInfo.hasStencil ? passInfo.stencilLoadOp : wgpu::LoadOp::Undefined,
-        .stencilStoreOp = passInfo.hasStencil ? passInfo.stencilStoreOp : wgpu::StoreOp::Undefined,
-        .stencilClearValue = passInfo.stencilClearValue,
+        .depthClearValue = passInfo.clearDepthValue,        
+        .stencilLoadOp = webgpu::g_graphicsConfig.depthStencilSupported
+                             ? (passInfo.clearDepth ? wgpu::LoadOp::Clear : wgpu::LoadOp::Load)
+                             : wgpu::LoadOp::Undefined,
+        .stencilStoreOp =
+            webgpu::g_graphicsConfig.depthStencilSupported ? wgpu::StoreOp::Store : wgpu::StoreOp::Undefined,
+        .stencilClearValue = 0,
     };
     depthStencilAttachmentPtr = &depthStencilAttachment;
   }

--- a/lib/gfx/encoding.cpp
+++ b/lib/gfx/encoding.cpp
@@ -232,8 +232,17 @@ void render(wgpu::CommandEncoder& cmd, FramePacket& frame, RenderPass& passInfo,
                                          : wgpu::LoadOp::Undefined,
         .depthStoreOp = passInfo.hasDepth ? passInfo.depthStoreOp : wgpu::StoreOp::Undefined,
         .depthClearValue = passInfo.clearDepthValue,
-        .stencilLoadOp = passInfo.hasStencil ? passInfo.stencilLoadOp : wgpu::LoadOp::Undefined,
-        .stencilStoreOp = passInfo.hasStencil ? passInfo.stencilStoreOp : wgpu::StoreOp::Undefined,
+        .stencilLoadOp =
+            passInfo.hasStencil
+                ? (passInfo.stencilLoadOp != wgpu::LoadOp::Undefined
+                       ? passInfo.stencilLoadOp
+                       : (passInfo.clearDepth ? wgpu::LoadOp::Clear : wgpu::LoadOp::Load))
+                : wgpu::LoadOp::Undefined,
+        .stencilStoreOp =
+            passInfo.hasStencil
+                ? (passInfo.stencilStoreOp != wgpu::StoreOp::Undefined ? passInfo.stencilStoreOp
+                                                                       : wgpu::StoreOp::Store)
+                : wgpu::StoreOp::Undefined,
         .stencilClearValue = passInfo.stencilClearValue,
     };
     depthStencilAttachmentPtr = &depthStencilAttachment;

--- a/lib/gfx/recording.cpp
+++ b/lib/gfx/recording.cpp
@@ -85,11 +85,11 @@ void set_efb_targets(RenderPass& pass) {
       webgpu::g_graphicsConfig.msaaSamples > 1 ? webgpu::g_frameBufferResolved.texture : webgpu::g_frameBuffer.texture;
   pass.copySourceView =
       webgpu::g_graphicsConfig.msaaSamples > 1 ? webgpu::g_frameBufferResolved.view : webgpu::g_frameBuffer.view;
-  pass.copySourceDepthView = webgpu::g_depthBuffer.view;
+  pass.copySourceDepthView = webgpu::g_depthBuffer.sampleView;
   pass.targetSize = webgpu::g_frameBuffer.size;
   pass.msaaSamples = webgpu::g_graphicsConfig.msaaSamples;
   pass.hasDepth = true;
-  pass.hasStencil = false;
+  pass.hasStencil = webgpu::g_graphicsConfig.depthStencilSupported;
 }
 
 struct OffscreenCacheKey {

--- a/lib/gx/command_processor.cpp
+++ b/lib/gx/command_processor.cpp
@@ -737,6 +737,8 @@ static void handle_bp(u32 value, bool bigEndian) {
     g_gxState.depthCompare = bp_get(value, 1, 0) != 0;
     g_gxState.depthFunc = static_cast<GXCompare>(bp_get(value, 3, 1));
     g_gxState.depthUpdate = bp_get(value, 1, 4) != 0;
+    // GX2 stencil: 
+    g_gxState.stencilEnable = false;
     g_gxState.stateDirty = true;
     break;
   }
@@ -1674,6 +1676,7 @@ static void push_gx_draw(GXPrimitive prim, GXVtxFmt fmt, u16 vtxCount, gfx::Rang
       .instanceCount = instanceCount,
       .bindGroups = bindGroups,
       .dstAlpha = g_gxState.dstAlpha,
+      .stencilRef = g_gxState.stencilRef,
   });
 }
 
@@ -1807,6 +1810,25 @@ void handle_aurora(const u8* data, u32& pos, u32 size, bool bigEndian) {
     pos += 4;
     g_gxState.clamp = read_f32(data + pos, bigEndian);
     pos += 4;
+    g_gxState.stateDirty = true;
+  } else if (subCmd == GX2_SET_STENCIL_MASK) {
+    CHECK(pos + 6 <= size, "GX2_SET_STENCIL_MASK read overrun");
+    g_gxState.stencilReadMask = data[pos];
+    g_gxState.stencilWriteMask = data[pos + 1];
+    g_gxState.stencilRef = data[pos + 2];
+    pos += 6;
+    g_gxState.stateDirty = true;
+  } else if (subCmd == GX2_SET_DEPTH_STENCIL_CONTROL) {
+    CHECK(pos + 13 <= size, "GX2_SET_DEPTH_STENCIL_CONTROL read overrun");
+    g_gxState.depthCompare = data[pos] != 0;
+    g_gxState.depthUpdate = data[pos + 1] != 0;
+    g_gxState.depthFunc = static_cast<GXCompare>(data[pos + 2]);
+    g_gxState.stencilEnable = data[pos + 3] != 0;
+    g_gxState.stencilFunc = static_cast<GXCompare>(data[pos + 5]);
+    g_gxState.stencilOpZPass = data[pos + 6];
+    g_gxState.stencilOpZFail = data[pos + 7];
+    g_gxState.stencilOpFail = data[pos + 8];
+    pos += 13;
     g_gxState.stateDirty = true;
   } else if (subCmd == GX_AURORA_DESTROY_TEXOBJ) {
     CHECK(pos + 4 <= size, "GX_AURORA_DESTROY_TEXOBJ read overrun");

--- a/lib/gx/command_processor.cpp
+++ b/lib/gx/command_processor.cpp
@@ -415,6 +415,7 @@ static void push_gx_draw(GXPrimitive prim, GXVtxFmt fmt, u16 vtxCount, gfx::Rang
       .instanceCount = instanceCount,
       .bindGroups = cache.bindGroups,
       .dstAlpha = state.dstAlpha,
+      .stencilRef = state.stencilRef,
   });
 }
 
@@ -645,6 +646,24 @@ void handle_aurora(Reader& reader) noexcept {
     gfx::begin_offscreen(width, height);
   } else if (subCmd == GX_AURORA_END_OFFSCREEN) {
     gfx::end_offscreen();
+  } else if (subCmd == GX2_SET_STENCIL_MASK) {
+    g_gxState.stencilReadMask = reader.read<u8>();
+    g_gxState.stencilWriteMask = reader.read<u8>();
+    g_gxState.stencilRef = reader.read<u8>();
+    reader.skip(3); // Back-face masks/reference are currently unused.
+    g_gxState.dirty |= DirtyPipeline;
+  } else if (subCmd == GX2_SET_DEPTH_STENCIL_CONTROL) {
+    g_gxState.depthCompare = reader.read<u8>() != 0;
+    g_gxState.depthUpdate = reader.read<u8>() != 0;
+    g_gxState.depthFunc = static_cast<GXCompare>(reader.read<u8>());
+    g_gxState.stencilEnable = reader.read<u8>() != 0;
+    reader.skip(1); // Back-face stencil enable is currently unused.
+    g_gxState.stencilFunc = static_cast<GXCompare>(reader.read<u8>());
+    g_gxState.stencilOpZPass = reader.read<u8>();
+    g_gxState.stencilOpZFail = reader.read<u8>();
+    g_gxState.stencilOpFail = reader.read<u8>();
+    reader.skip(4); // Back-face function/operations are currently unused.
+    g_gxState.dirty |= DirtyPipeline;
   } else if (subCmd == GX_AURORA_DESTROY_TEXOBJ) {
     evict_texture_object(reader.read<u32>());
   } else if (subCmd == GX_AURORA_DESTROY_TLUT) {

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -630,15 +630,39 @@ static inline wgpu::PrimitiveState to_primitive_state(GXCullMode gx_cullMode) {
   };
 }
 
+static wgpu::StencilOperation to_stencil_op(uint8_t op) noexcept {
+  switch (op) {
+  case 1: return wgpu::StencilOperation::Zero;
+  case 2: return wgpu::StencilOperation::Replace;
+  case 3: return wgpu::StencilOperation::IncrementClamp;
+  case 4: return wgpu::StencilOperation::DecrementClamp;
+  case 5: return wgpu::StencilOperation::Invert;
+  default: return wgpu::StencilOperation::Keep;  
+  }
+}
+
 wgpu::RenderPipeline build_pipeline(const PipelineConfig& config, ArrayRef<wgpu::VertexBufferLayout> vtxBuffers,
                                     wgpu::ShaderModule shader, const char* label) noexcept {
   ZoneScoped;
   const float depthBias = (UseReversedZ ? -1.0f : 1.0f) * std::bit_cast<float>(config.polygonOffsetBits);
   const float depthBiasSlopeScale = (UseReversedZ ? -1.0f : 1.0f) * std::bit_cast<float>(config.polygonOffsetScaleBits);
+  const bool stencilOn = g_graphicsConfig.depthStencilSupported && config.stencilEnable != 0;
+  const wgpu::StencilFaceState stencilFace =
+      stencilOn ? wgpu::StencilFaceState{
+                      .compare = to_compare_function(static_cast<GXCompare>(config.stencilFunc)),
+                      .failOp = to_stencil_op(config.stencilOpFail),
+                      .depthFailOp = to_stencil_op(config.stencilOpZFail),
+                      .passOp = to_stencil_op(config.stencilOpZPass),
+                  }
+                : wgpu::StencilFaceState{};
   const wgpu::DepthStencilState depthStencil{
       .format = g_graphicsConfig.depthFormat,
       .depthWriteEnabled = config.depthCompare && config.depthUpdate,
       .depthCompare = config.depthCompare ? to_compare_function(config.depthFunc) : wgpu::CompareFunction::Always,
+      .stencilFront = stencilFace,
+      .stencilBack = stencilFace,
+      .stencilReadMask = stencilOn ? static_cast<uint32_t>(config.stencilReadMask) : 0xFFFFFFFFu,
+      .stencilWriteMask = stencilOn ? static_cast<uint32_t>(config.stencilWriteMask) : 0xFFFFFFFFu,
       .depthBias = round_away_from_zero<int32_t>(depthBias),
       .depthBiasSlopeScale = depthBiasSlopeScale,
       .depthBiasClamp = std::bit_cast<float>(config.polygonOffsetClampBits),
@@ -778,6 +802,14 @@ void populate_pipeline_config(PipelineConfig& config, GXPrimitive primitive, GXV
       .depthUpdate = g_gxState.depthUpdate,
       .alphaUpdate = g_gxState.alphaUpdate,
       .colorUpdate = g_gxState.colorUpdate,
+      .stencilEnable = static_cast<uint8_t>(g_gxState.stencilEnable ? 1 : 0),
+      .stencilFunc = static_cast<uint8_t>(g_gxState.stencilFunc),
+      .stencilReadMask = g_gxState.stencilReadMask,
+      .stencilWriteMask = g_gxState.stencilWriteMask,
+      .stencilOpFail = g_gxState.stencilOpFail,
+      .stencilOpZFail = g_gxState.stencilOpZFail,
+      .stencilOpZPass = g_gxState.stencilOpZPass,
+      .stencilPad = 0,
   };
 }
 

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -313,16 +313,46 @@ void set_render_scissor(const gfx::ClipRect& scissor) noexcept {
 
 const gfx::TextureBind& get_texture(GXTexMapID id) noexcept { return g_gxState.textures[static_cast<size_t>(id)]; }
 
+static wgpu::StencilOperation to_stencil_op(uint8_t op) noexcept {
+  switch (op) {
+  case 1:
+    return wgpu::StencilOperation::Zero;
+  case 2:
+    return wgpu::StencilOperation::Replace;
+  case 3:
+    return wgpu::StencilOperation::IncrementClamp;
+  case 4:
+    return wgpu::StencilOperation::DecrementClamp;
+  case 5:
+    return wgpu::StencilOperation::Invert;
+  default:
+    return wgpu::StencilOperation::Keep;
+  }
+}
+
 wgpu::RenderPipeline build_pipeline(const PipelineConfig& config, ArrayRef<wgpu::VertexBufferLayout> vtxBuffers,
                                     wgpu::ShaderModule shader, const char* label) noexcept {
   ZoneScoped;
   const float depthBias = (UseReversedZ ? -1.0f : 1.0f) * std::bit_cast<float>(config.polygonOffsetBits);
   const float depthBiasSlopeScale = (UseReversedZ ? -1.0f : 1.0f) * std::bit_cast<float>(config.polygonOffsetScaleBits);
   const float depthBiasClamp = webgpu::g_hasCoreFeatures ? std::bit_cast<float>(config.polygonOffsetClampBits) : 0.0f;
+  const bool stencilOn = g_graphicsConfig.depthStencilSupported && config.stencilEnable != 0;
+  const wgpu::StencilFaceState stencilFace =
+      stencilOn ? wgpu::StencilFaceState{
+                      .compare = to_compare_function(static_cast<GXCompare>(config.stencilFunc)),
+                      .failOp = to_stencil_op(config.stencilOpFail),
+                      .depthFailOp = to_stencil_op(config.stencilOpZFail),
+                      .passOp = to_stencil_op(config.stencilOpZPass),
+                  }
+                : wgpu::StencilFaceState{};
   const wgpu::DepthStencilState depthStencil{
       .format = g_graphicsConfig.depthFormat,
       .depthWriteEnabled = config.depthCompare && config.depthUpdate,
       .depthCompare = config.depthCompare ? to_compare_function(config.depthFunc) : wgpu::CompareFunction::Always,
+      .stencilFront = stencilFace,
+      .stencilBack = stencilFace,
+      .stencilReadMask = stencilOn ? static_cast<uint32_t>(config.stencilReadMask) : 0xFFFFFFFFu,
+      .stencilWriteMask = stencilOn ? static_cast<uint32_t>(config.stencilWriteMask) : 0xFFFFFFFFu,
       .depthBias = round_away_from_zero<int32_t>(depthBias),
       .depthBiasSlopeScale = depthBiasSlopeScale,
       .depthBiasClamp = depthBiasClamp,
@@ -464,6 +494,14 @@ void populate_pipeline_config(PipelineConfig& config, GXPrimitive primitive, GXV
       .depthUpdate = g_gxState.depthUpdate,
       .alphaUpdate = g_gxState.alphaUpdate,
       .colorUpdate = g_gxState.colorUpdate,
+      .stencilEnable = static_cast<uint8_t>(g_gxState.stencilEnable ? 1 : 0),
+      .stencilFunc = static_cast<uint8_t>(g_gxState.stencilFunc),
+      .stencilReadMask = g_gxState.stencilReadMask,
+      .stencilWriteMask = g_gxState.stencilWriteMask,
+      .stencilOpFail = g_gxState.stencilOpFail,
+      .stencilOpZFail = g_gxState.stencilOpZFail,
+      .stencilOpZPass = g_gxState.stencilOpZPass,
+      .stencilPad = 0,
   };
 }
 

--- a/lib/gx/gx.hpp
+++ b/lib/gx/gx.hpp
@@ -368,6 +368,14 @@ struct GXState {
   bool depthUpdate = true;
   bool colorUpdate = true;
   bool alphaUpdate = true;
+  bool stencilEnable = false;
+  GXCompare stencilFunc = GX_ALWAYS;
+  u8 stencilRef = 0;
+  u8 stencilReadMask = 0xff;
+  u8 stencilWriteMask = 0xff;
+  u8 stencilOpFail = 0;
+  u8 stencilOpZFail = 0;
+  u8 stencilOpZPass = 0;
   u8 numChans = 0;
   u8 numIndStages = 0;
   u8 numTevStages = 0;

--- a/lib/gx/gx.hpp
+++ b/lib/gx/gx.hpp
@@ -379,6 +379,14 @@ struct GXState {
   bool depthUpdate = true;
   bool colorUpdate = true;
   bool alphaUpdate = true;
+  bool stencilEnable = false;
+  GXCompare stencilFunc = GX_ALWAYS;
+  u8 stencilRef = 0;
+  u8 stencilReadMask = 0xff;
+  u8 stencilWriteMask = 0xff;
+  u8 stencilOpFail = 0;
+  u8 stencilOpZFail = 0;
+  u8 stencilOpZPass = 0;
   u8 numChans = 0;
   u8 numIndStages = 0;
   u8 numTevStages = 0;

--- a/lib/gx/pipeline.cpp
+++ b/lib/gx/pipeline.cpp
@@ -32,6 +32,9 @@ void render(const DrawData& data, const wgpu::RenderPassEncoder& pass) {
     const wgpu::Color color{0.f, 0.f, 0.f, data.dstAlpha / 255.f};
     pass.SetBlendConstant(&color);
   }
+  if (data.stencilRef != 0) {
+    pass.SetStencilReference(data.stencilRef);
+  }
   if (data.indexCount == 0) {
     pass.Draw(data.vtxCount, data.instanceCount);
   } else {

--- a/lib/gx/pipeline.cpp
+++ b/lib/gx/pipeline.cpp
@@ -38,6 +38,7 @@ void render(const DrawData& data, const wgpu::RenderPassEncoder& pass) {
     const wgpu::Color color{0.f, 0.f, 0.f, data.dstAlpha / 255.f};
     pass.SetBlendConstant(&color);
   }
+  pass.SetStencilReference(data.stencilRef);
   if (data.indexCount == 0) {
     pass.Draw(data.vtxCount, data.instanceCount);
   } else {

--- a/lib/gx/pipeline.hpp
+++ b/lib/gx/pipeline.hpp
@@ -14,9 +14,10 @@ struct DrawData {
   uint32_t instanceCount;
   GXBindGroups bindGroups;
   uint32_t dstAlpha;
+  uint8_t stencilRef = 0; 
 };
 
-constexpr uint32_t GXPipelineConfigVersion = 13;
+constexpr uint32_t GXPipelineConfigVersion = 14;
 struct PipelineConfig {
   uint32_t version = GXPipelineConfigVersion;
   uint32_t msaaSamples = 1;
@@ -31,6 +32,14 @@ struct PipelineConfig {
   uint32_t polygonOffsetScaleBits;
   uint32_t polygonOffsetClampBits;
   bool depthCompare, depthUpdate, alphaUpdate, colorUpdate;
+  uint8_t stencilEnable;
+  uint8_t stencilFunc;     
+  uint8_t stencilReadMask;
+  uint8_t stencilWriteMask;
+  uint8_t stencilOpFail;     
+  uint8_t stencilOpZFail;
+  uint8_t stencilOpZPass;
+  uint8_t stencilPad;        
 };
 static_assert(std::has_unique_object_representations_v<PipelineConfig>);
 

--- a/lib/gx/pipeline.hpp
+++ b/lib/gx/pipeline.hpp
@@ -15,9 +15,10 @@ struct DrawData {
   uint32_t instanceCount;
   GXBindGroups bindGroups;
   uint32_t dstAlpha;
+  uint8_t stencilRef = 0;
 };
 
-constexpr uint32_t GXPipelineConfigVersion = 13;
+constexpr uint32_t GXPipelineConfigVersion = 14;
 struct PipelineConfig {
   uint32_t version = GXPipelineConfigVersion;
   uint32_t msaaSamples = 1;
@@ -32,6 +33,14 @@ struct PipelineConfig {
   uint32_t polygonOffsetScaleBits;
   uint32_t polygonOffsetClampBits;
   bool depthCompare, depthUpdate, alphaUpdate, colorUpdate;
+  uint8_t stencilEnable;
+  uint8_t stencilFunc;
+  uint8_t stencilReadMask;
+  uint8_t stencilWriteMask;
+  uint8_t stencilOpFail;
+  uint8_t stencilOpZFail;
+  uint8_t stencilOpZPass;
+  uint8_t stencilPad;
 };
 static_assert(std::has_unique_object_representations_v<PipelineConfig>);
 

--- a/lib/gx/regs.cpp
+++ b/lib/gx/regs.cpp
@@ -216,6 +216,8 @@ void bp_z_mode(u8, u32 value) noexcept {
   g_gxState.depthCompare = reg_get(value, 1, 0) != 0;
   g_gxState.depthFunc = static_cast<GXCompare>(reg_get(value, 3, 1));
   g_gxState.depthUpdate = reg_get(value, 1, 4) != 0;
+  // GX2 matches this behavior: writing Z mode disables stencil testing.
+  g_gxState.stencilEnable = false;
 }
 
 // Blend mode / cmode0 (0x41)

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -63,6 +63,8 @@ bool g_bcTexturesSupported = false;
 bool g_astcTexturesSupported = false;
 bool g_textureComponentSwizzleSupported = false;
 static std::atomic_bool g_initialized = false;
+static std::atomic_bool g_shuttingDown = false;
+bool g_depthStencilSupported;
 
 namespace {
 
@@ -356,6 +358,13 @@ static TextureWithSampler create_depth_texture(uint32_t width, uint32_t height) 
   };
   auto view = texture.CreateView(&viewDescriptor);
 
+  const wgpu::TextureViewDescriptor sampleViewDescriptor{
+      .label = "Depth sample view",
+      .dimension = wgpu::TextureViewDimension::e2D,
+      .aspect = wgpu::TextureAspect::DepthOnly,
+  };
+  auto sampleView = texture.CreateView(&sampleViewDescriptor);
+
   const wgpu::SamplerDescriptor samplerDescriptor{
       .label = "Depth sampler",
       .addressModeU = wgpu::AddressMode::ClampToEdge,
@@ -376,6 +385,7 @@ static TextureWithSampler create_depth_texture(uint32_t width, uint32_t height) 
       .size = size,
       .format = format,
       .sampler = std::move(sampler),
+      .sampleView = std::move(sampleView),
   };
 }
 
@@ -850,6 +860,7 @@ bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
     g_bcTexturesSupported = false;
     g_astcTexturesSupported = false;
     g_textureComponentSwizzleSupported = false;
+    g_depthStencilSupported = true;
     wgpu::SupportedFeatures supportedFeatures;
     g_adapter.GetFeatures(&supportedFeatures);
     for (size_t i = 0; i < supportedFeatures.featureCount; ++i) {
@@ -1000,9 +1011,10 @@ bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
               .height = size.native_fb_height,
               .presentMode = presentMode,
           },
-      .depthFormat = wgpu::TextureFormat::Depth32Float,
+      .depthFormat = wgpu::TextureFormat::Depth24PlusStencil8,
       .msaaSamples = g_config.msaa,
       .textureAnisotropy = g_config.maxTextureAnisotropy,
+      .depthStencilSupported = g_depthStencilSupported,
   };
   create_copy_pipeline();
   create_resample_pipeline();

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -384,6 +384,13 @@ static TextureWithSampler create_depth_texture(uint32_t width, uint32_t height) 
   };
   auto view = texture.CreateView(&viewDescriptor);
 
+  const wgpu::TextureViewDescriptor sampleViewDescriptor{
+      .label = "Depth sample view",
+      .dimension = wgpu::TextureViewDimension::e2D,
+      .aspect = wgpu::TextureAspect::DepthOnly,
+  };
+  auto sampleView = texture.CreateView(&sampleViewDescriptor);
+
   const wgpu::SamplerDescriptor samplerDescriptor{
       .label = "Depth sampler",
       .addressModeU = wgpu::AddressMode::ClampToEdge,
@@ -404,6 +411,7 @@ static TextureWithSampler create_depth_texture(uint32_t width, uint32_t height) 
       .size = size,
       .format = format,
       .sampler = std::move(sampler),
+      .sampleView = std::move(sampleView),
   };
 }
 
@@ -1038,9 +1046,10 @@ bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
               .height = size.native_fb_height,
               .presentMode = presentMode,
           },
-      .depthFormat = wgpu::TextureFormat::Depth32Float,
+      .depthFormat = wgpu::TextureFormat::Depth24PlusStencil8,
       .msaaSamples = g_config.msaa,
       .textureAnisotropy = g_config.maxTextureAnisotropy,
+      .depthStencilSupported = true,
   };
   create_copy_pipeline();
   create_resample_pipeline();

--- a/lib/webgpu/gpu.hpp
+++ b/lib/webgpu/gpu.hpp
@@ -16,6 +16,7 @@ struct GraphicsConfig {
   wgpu::TextureFormat depthFormat;
   uint32_t msaaSamples;
   uint16_t textureAnisotropy;
+  bool depthStencilSupported = false;
 };
 struct TextureWithSampler {
   wgpu::Texture texture;
@@ -23,6 +24,7 @@ struct TextureWithSampler {
   wgpu::Extent3D size;
   wgpu::TextureFormat format;
   wgpu::Sampler sampler;
+  wgpu::TextureView sampleView;
 };
 struct Viewport {
   float left;


### PR DESCRIPTION
We would need it basically for 2 functions (GX2SetStencilMask and GX2SetDepthStencilControl) used in src\d\actor\d_a_mirror.cpp for TP HD temple of time.