### PR TITLE
Include cstring in CardGciFolder.cpp

### DIFF
--- a/lib/card/CardGciFolder.cpp
+++ b/lib/card/CardGciFolder.cpp
@@ -1,5 +1,7 @@
 #include "CardGciFolder.hpp"
 
+#include <cstring>
+
 #include <filesystem>
 #include "../fs_helper.hpp"
 


### PR DESCRIPTION
I don't know what caused it, but the last 2 days I get compile errors and including cstring in this file seems to fix it.


```
FAILED: [code=1] extern/aurora/CMakeFiles/aurora_card.dir/lib/card/CardGciFolder.cpp.o 
/usr/bin/clang++ -DAURORA -DAURORA_ENABLE_GX -DAURORA_ENABLE_RMLUI -DFMT_SHARED -DIMGUI_ENABLE_FREETYPE -DIMGUI_USER_CONFIG=\"aurora/imgui_config.h\" -DRMLUI_SDL_VERSION_MAJOR=3 -DTARGET_PC -DWEBGPU_DAWN -I/home/rodney/tmp/dusklight/extern/aurora/include -I/home/rodney/tmp/dusklight/build/_deps/xxhash-src/cmake_unofficial/.. -I/home/rodney/tmp/dusklight/build/_deps/imgui-src -I/home/rodney/tmp/dusklight/build/_deps/rmlui-src/Include -I/home/rodney/tmp/dusklight/build/_deps/rmlui-src/Backends -flto=thin -DNDEBUG -std=gnu++20 -fPIC -MD -MT extern/aurora/CMakeFiles/aurora_card.dir/lib/card/CardGciFolder.cpp.o -MF extern/aurora/CMakeFiles/aurora_card.dir/lib/card/CardGciFolder.cpp.o.d -o extern/aurora/CMakeFiles/aurora_card.dir/lib/card/CardGciFolder.cpp.o -c /home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:108:3: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  108 |   std::memcpy(gciFileHeader->m_game, m_game, 4);
      |   ^~~~~~~~~~~
      |   memcpy
/usr/include/string.h:47:14: note: 'memcpy' declared here
   47 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:109:3: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  109 |   std::memcpy(gciFileHeader->m_maker, m_maker, 2);
      |   ^~~~~~~~~~~
      |   memcpy
/usr/include/string.h:47:14: note: 'memcpy' declared here
   47 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:223:3: error: no member named 'strncpy' in namespace 'std'; did you mean simply 'strncpy'?
  223 |   std::strncpy(statOut.x0_fileName, file->m_filename, 32);
      |   ^~~~~~~~~~~~
      |   strncpy
/usr/include/string.h:159:14: note: 'strncpy' declared here
  159 | extern char *strncpy (char *__restrict __dest,
      |              ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:288:26: error: no member named 'strlen' in namespace 'std'; did you mean simply 'strlen'?
  288 |   if (game != nullptr && std::strlen(game) == 4) {
      |                          ^~~~~~~~~~~
      |                          strlen
/usr/include/string.h:439:15: note: 'strlen' declared here
  439 | extern size_t strlen (const char *__s)
      |               ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:289:5: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  289 |     std::memcpy(m_game, game, 4);
      |     ^~~~~~~~~~~
      |     memcpy
/usr/include/string.h:47:14: note: 'memcpy' declared here
   47 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:294:7: error: no member named 'strlen' in namespace 'std'; did you mean simply 'strlen'?
  294 |   if (std::strlen(m_game) == sizeof(m_game) - 1) {
      |       ^~~~~~~~~~~
      |       strlen
/usr/include/string.h:439:15: note: 'strlen' declared here
  439 | extern size_t strlen (const char *__s)
      |               ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:302:27: error: no member named 'strlen' in namespace 'std'; did you mean simply 'strlen'?
  302 |   if (maker != nullptr && std::strlen(maker) == 2) {
      |                           ^~~~~~~~~~~
      |                           strlen
/usr/include/string.h:439:15: note: 'strlen' declared here
  439 | extern size_t strlen (const char *__s)
      |               ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:303:5: error: no member named 'memcpy' in namespace 'std'; did you mean simply 'memcpy'?
  303 |     std::memcpy(m_maker, maker, 2);
      |     ^~~~~~~~~~~
      |     memcpy
/usr/include/string.h:47:14: note: 'memcpy' declared here
   47 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
/home/rodney/tmp/dusklight/extern/aurora/lib/card/CardGciFolder.cpp:308:7: error: no member named 'strlen' in namespace 'std'; did you mean simply 'strlen'?
  308 |   if (std::strlen(m_maker) == sizeof(m_maker) - 1) {
      |       ^~~~~~~~~~~
      |       strlen
/usr/include/string.h:439:15: note: 'strlen' declared here
  439 | extern size_t strlen (const char *__s)
      |               ^
9 errors generated.
```