### PR TITLE
dvd: expose generation-safe logical disc reads

### DIFF
--- a/include/aurora/dvd.h
+++ b/include/aurora/dvd.h
@@ -6,7 +6,24 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <dolphin/types.h>
+
+typedef enum AuroraDiscResult {
+  AURORA_DISC_OK = 0,
+  AURORA_DISC_UNAVAILABLE = 1,
+  AURORA_DISC_INVALID_ARGUMENT = 2,
+  AURORA_DISC_OUT_OF_RANGE = 3,
+  AURORA_DISC_GENERATION_CHANGED = 4,
+  AURORA_DISC_IO_ERROR = 5,
+} AuroraDiscResult;
+
+typedef struct AuroraDiscInfo {
+  char game_id[7];
+  uint64_t logical_size;
+  uint64_t generation;
+} AuroraDiscInfo;
 
 /**
  * Open a GC/Wii disc image for use by the DVD API.
@@ -19,6 +36,21 @@ bool aurora_dvd_open(const char* disc_path);
  * Close the disc image and free all resources.
  */
 void aurora_dvd_close(void);
+
+/**
+ * Return identity and logical size for the active disc.
+ *
+ * The generation is nonzero while a disc is active and becomes stale after a
+ * successful disc transition.
+ */
+AuroraDiscResult aurora_dvd_get_info(AuroraDiscInfo* out_info);
+
+/**
+ * Read exact logical disc bytes using a generation returned by
+ * aurora_dvd_get_info.
+ */
+AuroraDiscResult aurora_dvd_read_at(
+    uint64_t expected_generation, uint64_t offset, void* buffer, size_t size);
 
 /**
  * OVERLAY FILES!

--- a/lib/dolphin/dvd/dvd.cpp
+++ b/lib/dolphin/dvd/dvd.cpp
@@ -91,8 +91,10 @@ public:
 };
 
 CommandDataNod* s_disc;
+std::mutex s_discMutex;
+uint64_t s_discGeneration = 0;
 
-void clearState() {
+void clearStateLocked() {
   if (s_partition != nullptr) {
     nod_free(s_partition);
     s_partition = nullptr;
@@ -108,6 +110,88 @@ void clearState() {
   s_currentPath = "/";
   s_diskID = {};
   s_initialized = false;
+}
+
+bool advanceDiscGenerationLocked() {
+  if (s_discGeneration == std::numeric_limits<uint64_t>::max()) {
+    return false;
+  }
+  ++s_discGeneration;
+  return true;
+}
+
+bool validLogicalDiscSize(const uint64_t size) {
+  return size != 0 && size <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+}
+
+s32 readFromHandle(CommandDataBase* handle, void* out, s32 length, s32 offset, u32* transferredOut);
+
+AuroraDiscResult getActiveDiscInfoLocked(AuroraDiscInfo* outInfo) {
+  if (s_disc == nullptr) {
+    return AURORA_DISC_UNAVAILABLE;
+  }
+
+  const uint64_t logicalSize = nod_disc_size(s_disc->handle);
+  NodDiscHeader header{};
+  if (!validLogicalDiscSize(logicalSize) ||
+      nod_disc_header(s_disc->handle, &header) != NOD_RESULT_OK)
+  {
+    return AURORA_DISC_IO_ERROR;
+  }
+
+  std::memcpy(outInfo->game_id, header.game_id, sizeof(header.game_id));
+  outInfo->game_id[sizeof(header.game_id)] = '\0';
+  outInfo->logical_size = logicalSize;
+  outInfo->generation = s_discGeneration;
+  return AURORA_DISC_OK;
+}
+
+AuroraDiscResult readActiveDiscLocked(
+    uint64_t expectedGeneration, uint64_t offset, void* buffer, size_t size) {
+  if (s_disc == nullptr) {
+    return AURORA_DISC_UNAVAILABLE;
+  }
+
+  const uint64_t logicalSize = nod_disc_size(s_disc->handle);
+  if (!validLogicalDiscSize(logicalSize)) {
+    return AURORA_DISC_IO_ERROR;
+  }
+  if (expectedGeneration != s_discGeneration) {
+    return AURORA_DISC_GENERATION_CHANGED;
+  }
+  if (offset > logicalSize || size > logicalSize - offset)
+  {
+    return AURORA_DISC_OUT_OF_RANGE;
+  }
+  if (size == 0) {
+    return AURORA_DISC_OK;
+  }
+  if (offset > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+      s_disc->seek(static_cast<int64_t>(offset), 0) < 0)
+  {
+    return AURORA_DISC_IO_ERROR;
+  }
+
+  auto* writePtr = static_cast<uint8_t*>(buffer);
+  size_t totalRead = 0;
+  while (totalRead < size) {
+    const int64_t read = s_disc->read(writePtr + totalRead, size - totalRead);
+    if (read <= 0 || static_cast<uint64_t>(read) > size - totalRead) {
+      return AURORA_DISC_IO_ERROR;
+    }
+    totalRead += static_cast<size_t>(read);
+  }
+  return AURORA_DISC_OK;
+}
+
+s32 readActiveDisc(void* out, s32 length, s32 offset, u32* transferredOut) {
+  std::lock_guard lock{s_discMutex};
+  return readFromHandle(s_disc, out, length, offset, transferredOut);
+}
+
+int64_t seekActiveDisc(s32 offset) {
+  std::lock_guard lock{s_discMutex};
+  return s_disc != nullptr ? s_disc->seek(static_cast<int64_t>(offset), 0) : -1;
 }
 
 bool isValidEntryNum(s32 entry) {
@@ -317,11 +401,11 @@ bool isCommandBlockIdle(const DVDCommandBlock* block) {
   return state != DVD_STATE_BUSY && state != DVD_STATE_WAITING;
 }
 
-CommandDataBase* getCommandHandle(DVDCommandBlock* block) {
+CommandDataBase* getPerFileCommandHandle(DVDCommandBlock* block) {
   if (block != nullptr && block->userData != nullptr) {
     return static_cast<CommandDataBase*>(block->userData);
   }
-  return s_disc;
+  return nullptr;
 }
 
 void beginCommand(DVDCommandBlock* block, u32 command, void* addr, u32 length, u32 offset, DVDCBCallback callback) {
@@ -522,13 +606,17 @@ private:
   static std::pair<s32, u32> perform_command(DVDCommandBlock* block) {
     s32 result;
     u32 transferred = 0;
+    auto* handle = getPerFileCommandHandle(block);
     if (block->command == DVD_COMMAND_SEEK) {
-      auto* handle = getCommandHandle(block);
-      const int64_t seek = handle != nullptr ? handle->seek(block->offset, 0) : -1;
+      const int64_t seek =
+          handle != nullptr ? handle->seek(block->offset, 0) : seekActiveDisc(block->offset);
       result = seek < 0 ? DVD_RESULT_FATAL_ERROR : DVD_RESULT_GOOD;
     } else {
-      result = readFromHandle(getCommandHandle(block), block->addr, static_cast<s32>(block->length),
-                              static_cast<s32>(block->offset), &transferred);
+      result = handle != nullptr
+                   ? readFromHandle(handle, block->addr, static_cast<s32>(block->length),
+                         static_cast<s32>(block->offset), &transferred)
+                   : readActiveDisc(block->addr, static_cast<s32>(block->length),
+                         static_cast<s32>(block->offset), &transferred);
     }
     return {result, transferred};
   }
@@ -653,10 +741,15 @@ bool aurora_dvd_open(const char* disc_path) {
   }
 
   s_worker.stop();
-  clearState();
+  std::unique_lock lock{s_discMutex};
+  const bool removedActiveDisc = s_disc != nullptr;
+  clearStateLocked();
 
   SDL_IOStream* io = SDL_IOFromFile(disc_path, "rb");
   if (io == nullptr) {
+    if (removedActiveDisc) {
+      advanceDiscGenerationLocked();
+    }
     return false;
   }
 
@@ -673,7 +766,10 @@ bool aurora_dvd_open(const char* disc_path) {
   NodHandle* discHandle;
   NodResult result = nod_disc_open_stream(&stream, &options, &discHandle);
   if (result != NOD_RESULT_OK || discHandle == nullptr) {
-    clearState();
+    clearStateLocked();
+    if (removedActiveDisc) {
+      advanceDiscGenerationLocked();
+    }
     return false;
   }
 
@@ -681,7 +777,10 @@ bool aurora_dvd_open(const char* disc_path) {
 
   result = nod_disc_open_partition_kind(s_disc->handle, NOD_PARTITION_KIND_DATA, nullptr, &s_partition);
   if (result != NOD_RESULT_OK || s_partition == nullptr) {
-    clearState();
+    clearStateLocked();
+    if (removedActiveDisc) {
+      advanceDiscGenerationLocked();
+    }
     return false;
   }
 
@@ -698,20 +797,49 @@ bool aurora_dvd_open(const char* disc_path) {
   }
 
   if (!rebuildFST()) {
-    clearState();
+    clearStateLocked();
+    if (removedActiveDisc) {
+      advanceDiscGenerationLocked();
+    }
+    return false;
+  }
+  if (!advanceDiscGenerationLocked()) {
+    clearStateLocked();
     return false;
   }
 
   s_currentDir = 0;
   s_currentPath = "/";
   s_initialized = true;
+  lock.unlock();
   s_worker.start();
   return true;
 }
 
 void aurora_dvd_close(void) {
   s_worker.stop();
-  clearState();
+  std::lock_guard lock{s_discMutex};
+  if (s_disc != nullptr) {
+    clearStateLocked();
+    advanceDiscGenerationLocked();
+  }
+}
+
+AuroraDiscResult aurora_dvd_get_info(AuroraDiscInfo* outInfo) {
+  if (outInfo == nullptr) {
+    return AURORA_DISC_INVALID_ARGUMENT;
+  }
+  std::lock_guard lock{s_discMutex};
+  return getActiveDiscInfoLocked(outInfo);
+}
+
+AuroraDiscResult aurora_dvd_read_at(
+    uint64_t expectedGeneration, uint64_t offset, void* buffer, size_t size) {
+  if (buffer == nullptr && size != 0) {
+    return AURORA_DISC_INVALID_ARGUMENT;
+  }
+  std::lock_guard lock{s_discMutex};
+  return readActiveDiscLocked(expectedGeneration, offset, buffer, size);
 }
 
 void DVDInit(void) {}
@@ -1368,7 +1496,8 @@ DVDDiskID* DVDGenerateDiskID(DVDDiskID* id, const char* game, const char* compan
 
 BOOL DVDLowRead(void* addr, u32 length, u32 offset, DVDLowCallback callback) {
   u32 transferred = 0;
-  s32 result = readFromHandle(s_disc, addr, static_cast<s32>(length), static_cast<s32>(offset), &transferred);
+  s32 result =
+      readActiveDisc(addr, static_cast<s32>(length), static_cast<s32>(offset), &transferred);
   if (callback != nullptr) {
     callback(static_cast<u32>((result >= 0) ? DVD_RESULT_GOOD : DVD_RESULT_FATAL_ERROR));
   }
@@ -1376,7 +1505,7 @@ BOOL DVDLowRead(void* addr, u32 length, u32 offset, DVDLowCallback callback) {
 }
 
 BOOL DVDLowSeek(u32 offset, DVDLowCallback callback) {
-  const int64_t seek = s_disc != nullptr ? s_disc->seek(static_cast<int64_t>(offset), 0) : -1;
+  const int64_t seek = seekActiveDisc(static_cast<s32>(offset));
   if (callback != nullptr) {
     callback(static_cast<u32>((seek >= 0) ? DVD_RESULT_GOOD : DVD_RESULT_FATAL_ERROR));
   }

--- a/tests/test_dvd.cpp
+++ b/tests/test_dvd.cpp
@@ -3,9 +3,12 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
+#include <limits>
 #include <thread>
 #include <vector>
 
@@ -160,11 +163,27 @@ TEST(DVDNoDisc, GetCurrentDir) {
   EXPECT_STREQ(buf, "/");
 }
 
+TEST(DVDNoDisc, LogicalReadApi) {
+  aurora_dvd_close();
+  AuroraDiscInfo info{};
+  EXPECT_EQ(aurora_dvd_get_info(nullptr), AURORA_DISC_INVALID_ARGUMENT);
+  EXPECT_EQ(aurora_dvd_get_info(&info), AURORA_DISC_UNAVAILABLE);
+  EXPECT_EQ(aurora_dvd_read_at(1, 0, nullptr, 1), AURORA_DISC_INVALID_ARGUMENT);
+  EXPECT_EQ(aurora_dvd_read_at(1, 0, nullptr, 0), AURORA_DISC_UNAVAILABLE);
+}
+
 // =============================================================================
 // Tests that require a disc image (conditionally compiled)
 // =============================================================================
 
 #ifdef DVD_TEST_IMAGE
+
+std::atomic<AuroraDiscResult> s_lowReadInfoResult{AURORA_DISC_UNAVAILABLE};
+
+void lowReadReenterCallback(u32) {
+  AuroraDiscInfo info{};
+  s_lowReadInfoResult.store(aurora_dvd_get_info(&info), std::memory_order_release);
+}
 
 class DVDDiscTest : public ::testing::Test {
 protected:
@@ -352,6 +371,123 @@ TEST_F(DVDDiscTest, DiskID) {
     }
   }
   EXPECT_TRUE(hasGameName);
+}
+
+TEST(DVDDiscService, ContractAndTransitions) {
+  aurora_dvd_close();
+
+  AuroraDiscInfo info{};
+  EXPECT_EQ(aurora_dvd_get_info(nullptr), AURORA_DISC_INVALID_ARGUMENT);
+  EXPECT_EQ(aurora_dvd_get_info(&info), AURORA_DISC_UNAVAILABLE);
+
+  ASSERT_TRUE(aurora_dvd_open(DVD_TEST_IMAGE));
+  ASSERT_EQ(aurora_dvd_get_info(&info), AURORA_DISC_OK);
+  ASSERT_NE(info.generation, 0u);
+  ASSERT_NE(info.logical_size, 0u);
+  EXPECT_EQ(info.game_id[6], '\0');
+
+  constexpr uint64_t kOffset = 1;
+  constexpr size_t kReadSize = 31;
+  ASSERT_GT(info.logical_size, kOffset + kReadSize);
+  std::vector<uint8_t> expected(kReadSize);
+  std::ifstream image(DVD_TEST_IMAGE, std::ios::binary);
+  ASSERT_TRUE(image.good());
+  image.seekg(static_cast<std::streamoff>(kOffset));
+  image.read(reinterpret_cast<char*>(expected.data()), static_cast<std::streamsize>(expected.size()));
+  ASSERT_EQ(image.gcount(), static_cast<std::streamsize>(expected.size()));
+
+  std::vector<uint8_t> actual(kReadSize + 1);
+  EXPECT_EQ(aurora_dvd_read_at(
+                info.generation, kOffset, actual.data() + 1, kReadSize),
+      AURORA_DISC_OK);
+  EXPECT_EQ(0, std::memcmp(actual.data() + 1, expected.data(), expected.size()));
+  EXPECT_EQ(aurora_dvd_read_at(info.generation, info.logical_size, nullptr, 0), AURORA_DISC_OK);
+  EXPECT_EQ(aurora_dvd_read_at(info.generation, info.logical_size + 1, nullptr, 0),
+      AURORA_DISC_OUT_OF_RANGE);
+  EXPECT_EQ(aurora_dvd_read_at(info.generation, info.logical_size, actual.data(), 1),
+      AURORA_DISC_OUT_OF_RANGE);
+  EXPECT_EQ(aurora_dvd_read_at(info.generation, std::numeric_limits<uint64_t>::max(), nullptr, 0),
+      AURORA_DISC_OUT_OF_RANGE);
+  EXPECT_EQ(aurora_dvd_read_at(0, 0, nullptr, 0), AURORA_DISC_GENERATION_CHANGED);
+  EXPECT_EQ(aurora_dvd_read_at(info.generation, 0, nullptr, 1), AURORA_DISC_INVALID_ARGUMENT);
+
+  std::vector<uint8_t> expectedAt17(kReadSize);
+  image.clear();
+  image.seekg(17);
+  image.read(
+      reinterpret_cast<char*>(expectedAt17.data()), static_cast<std::streamsize>(expectedAt17.size()));
+  ASSERT_EQ(image.gcount(), static_cast<std::streamsize>(expectedAt17.size()));
+  std::atomic<bool> readsUntorn{true};
+  auto readAt = [&](uint64_t offset, const std::vector<uint8_t>& reference) {
+    for (int i = 0; i < 16; ++i) {
+      std::vector<uint8_t> bytes(reference.size());
+      if (aurora_dvd_read_at(info.generation, offset, bytes.data(), bytes.size()) !=
+              AURORA_DISC_OK ||
+          bytes != reference)
+      {
+        readsUntorn.store(false, std::memory_order_release);
+        return;
+      }
+    }
+  };
+  std::thread first(readAt, kOffset, std::cref(expected));
+  std::thread second(readAt, 17, std::cref(expectedAt17));
+  first.join();
+  second.join();
+  EXPECT_TRUE(readsUntorn.load(std::memory_order_acquire));
+
+  s_lowReadInfoResult.store(AURORA_DISC_UNAVAILABLE, std::memory_order_release);
+  std::vector<uint8_t> lowRead(32);
+  EXPECT_EQ(DVDLowRead(lowRead.data(), lowRead.size(), 0, lowReadReenterCallback), TRUE);
+  EXPECT_EQ(s_lowReadInfoResult.load(std::memory_order_acquire), AURORA_DISC_OK);
+
+  AuroraDiscInfo beforeRace{};
+  ASSERT_EQ(aurora_dvd_get_info(&beforeRace), AURORA_DISC_OK);
+  std::atomic<bool> started{false};
+  std::atomic<AuroraDiscResult> raceResult{AURORA_DISC_IO_ERROR};
+  std::thread racingRead([&] {
+    std::vector<uint8_t> bytes(32);
+    started.store(true, std::memory_order_release);
+    raceResult.store(
+        aurora_dvd_read_at(beforeRace.generation, 0, bytes.data(), bytes.size()),
+        std::memory_order_release);
+  });
+  while (!started.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  aurora_dvd_close();
+  ASSERT_TRUE(aurora_dvd_open(DVD_TEST_IMAGE));
+  racingRead.join();
+  const AuroraDiscResult completedRace = raceResult.load(std::memory_order_acquire);
+  EXPECT_TRUE(completedRace == AURORA_DISC_OK || completedRace == AURORA_DISC_UNAVAILABLE ||
+      completedRace == AURORA_DISC_GENERATION_CHANGED);
+
+  AuroraDiscInfo afterReopen{};
+  ASSERT_EQ(aurora_dvd_get_info(&afterReopen), AURORA_DISC_OK);
+  EXPECT_EQ(afterReopen.generation, beforeRace.generation + 2);
+  EXPECT_EQ(aurora_dvd_read_at(beforeRace.generation, 0, actual.data(), 1),
+      AURORA_DISC_GENERATION_CHANGED);
+
+  ASSERT_FALSE(aurora_dvd_open("definitely-not-an-aurora-disc-image"));
+  EXPECT_EQ(aurora_dvd_get_info(&info), AURORA_DISC_UNAVAILABLE);
+  ASSERT_TRUE(aurora_dvd_open(DVD_TEST_IMAGE));
+  ASSERT_EQ(aurora_dvd_get_info(&info), AURORA_DISC_OK);
+  EXPECT_EQ(info.generation, afterReopen.generation + 2);
+
+  AuroraDiscInfo replacement{};
+  ASSERT_TRUE(aurora_dvd_open(DVD_TEST_IMAGE));
+  ASSERT_EQ(aurora_dvd_get_info(&replacement), AURORA_DISC_OK);
+  EXPECT_EQ(replacement.generation, info.generation + 1);
+  EXPECT_EQ(aurora_dvd_read_at(info.generation, 0, actual.data(), 1),
+      AURORA_DISC_GENERATION_CHANGED);
+
+  aurora_dvd_close();
+  aurora_dvd_close();
+  ASSERT_FALSE(aurora_dvd_open("definitely-not-an-aurora-disc-image"));
+  ASSERT_TRUE(aurora_dvd_open(DVD_TEST_IMAGE));
+  ASSERT_EQ(aurora_dvd_get_info(&info), AURORA_DISC_OK);
+  EXPECT_EQ(info.generation, replacement.generation + 2);
+  aurora_dvd_close();
 }
 
 #endif // DVD_TEST_IMAGE


### PR DESCRIPTION
## Summary

- expose logical disc metadata and generation through a small C API
- add generation-checked reads against the currently mounted disc
- serialize disc replacement and reads so callers cannot observe a mixed disc
- route existing low-level worker reads through the same synchronization

## Motivation

Hosts that load external modules need a safe way to read logical disc bytes
without exposing Aurora or nod internals. The generation token lets a caller
fail closed when the mounted image changes between discovery and a read.

## Validation

- `DVDNoDisc.*`: 10/10 passed
- AddressSanitizer + UndefinedBehaviorSanitizer: 10/10 passed
- ThreadSanitizer: 10/10 passed
- `git diff --check`
- independent Luna Max review: PASS

Tests covering successful reads and disc transitions are included behind the
existing `DVD_TEST_IMAGE` switch. No private disc image was used for this PR.
