### PR TITLE
Add antialiasing support. FXAA post-process pass, depth-readback MSAA support, and fxaa blur fix

### DIFF
--- a/include/aurora/aurora.h
+++ b/include/aurora/aurora.h
@@ -138,6 +138,13 @@ void aurora_set_background_input(bool value);
 void aurora_set_resampler(AuroraSampler sampler);
 /** Sets the clock timescale. Default 1.0f. 0.0f is paused. Range 0.0f-16.0f. */
 void aurora_set_timescale(float scale);
+void aurora_set_fxaa_enabled(bool enabled);
+// Must be called once per rendered frame, after the frame's HUD has been drawn (same point mods'
+// GFX_STAGE_FRAME_AFTER_HUD hook runs from) and before aurora_end_frame(). No-ops if FXAA is
+// disabled. FXAA needs to sample the finished frame, and by the time aurora_end_frame() runs, RmlUI
+// has already composited its own backdrop (blurred menus, popups) from the frame as it stood before
+// this call -- queuing any later would make FXAA invisible behind that UI.
+void aurora_queue_fxaa_pass();
 
 AuroraBackend aurora_get_backend();
 const AuroraBackend* aurora_get_available_backends(size_t* count);

--- a/include/aurora/aurora.h
+++ b/include/aurora/aurora.h
@@ -139,11 +139,12 @@ void aurora_set_resampler(AuroraSampler sampler);
 /** Sets the clock timescale. Default 1.0f. 0.0f is paused. Range 0.0f-16.0f. */
 void aurora_set_timescale(float scale);
 void aurora_set_fxaa_enabled(bool enabled);
-// Must be called once per rendered frame, after the frame's HUD has been drawn (same point mods'
-// GFX_STAGE_FRAME_AFTER_HUD hook runs from) and before aurora_end_frame(). No-ops if FXAA is
-// disabled. FXAA needs to sample the finished frame, and by the time aurora_end_frame() runs, RmlUI
-// has already composited its own backdrop (blurred menus, popups) from the frame as it stood before
-// this call -- queuing any later would make FXAA invisible behind that UI.
+// Must be called once per rendered frame, before the frame's HUD is drawn (same point mods'
+// GFX_STAGE_FRAME_BEFORE_HUD hook runs from) and while the EFB render pass is still open. No-ops
+// if FXAA is disabled. FXAA draws its smoothed result back into the EFB in place, so it must run
+// before the HUD (hearts, text, menu icons) so the HUD layers on top of it untouched afterward --
+// running it after the HUD would smooth HUD edges/text along with real geometry, and running it
+// outside an active render pass is a no-op (see gfx::push_custom_draw's doc comment).
 void aurora_queue_fxaa_pass();
 
 AuroraBackend aurora_get_backend();

--- a/lib/aurora.cpp
+++ b/lib/aurora.cpp
@@ -270,7 +270,7 @@ void end_frame() noexcept {
   gfx::finish();
   auto imguiDrawData = imgui::freeze();
 
-  const auto& presentSource = webgpu::present_source();
+  const auto& presentSource = webgpu::aa_present_source();
   const auto viewport = webgpu::calculate_present_viewport(webgpu::g_graphicsConfig.surfaceConfiguration.width,
                                                            webgpu::g_graphicsConfig.surfaceConfiguration.height,
                                                            presentSource.size.width, presentSource.size.height);
@@ -476,3 +476,15 @@ void aurora_set_resampler(AuroraSampler sampler) {
 }
 void aurora_set_timescale(float scale) { aurora::time::set_scale(scale); }
 float aurora_get_timescale() { return aurora::time::scale(); }
+void aurora_set_fxaa_enabled(bool enabled) {
+#ifdef AURORA_ENABLE_GX
+  aurora::webgpu::set_fxaa_enabled(enabled);
+#else
+  (void)enabled;
+#endif
+}
+void aurora_queue_fxaa_pass() {
+#ifdef AURORA_ENABLE_GX
+  aurora::webgpu::queue_fxaa_pass();
+#endif
+}

--- a/lib/aurora.cpp
+++ b/lib/aurora.cpp
@@ -270,7 +270,7 @@ void end_frame() noexcept {
   gfx::finish();
   auto imguiDrawData = imgui::freeze();
 
-  const auto& presentSource = webgpu::aa_present_source();
+  const auto& presentSource = webgpu::present_source();
   const auto viewport = webgpu::calculate_present_viewport(webgpu::g_graphicsConfig.surfaceConfiguration.width,
                                                            webgpu::g_graphicsConfig.surfaceConfiguration.height,
                                                            presentSource.size.width, presentSource.size.height);

--- a/lib/gfx/depth_peek.cpp
+++ b/lib/gfx/depth_peek.cpp
@@ -76,6 +76,8 @@ std::array<Slot, SlotCount> g_slots;
 size_t g_nextSlot = 0;
 wgpu::BindGroupLayout g_bindGroupLayout;
 wgpu::ComputePipeline g_pipeline;
+wgpu::BindGroupLayout g_bindGroupLayoutMS;
+wgpu::ComputePipeline g_pipelineMS;
 bool g_snapshotRequested = false;
 Clock::time_point g_nextSnapshotTime;
 LatestSnapshot g_latest;
@@ -126,17 +128,41 @@ fn cs_main(@builtin(global_invocation_id) id: vec3u) {
 }
 )"sv;
 
-std::string build_shader_source() {
+// Multisampled variant: reads the multisampled EFB depth buffer at sample index 0.
+constexpr std::string_view ShaderMainMS = R"(
+@group(0) @binding(0) var src: texture_depth_multisampled_2d;
+
+fn load_depth(coord: vec2i) -> f32 {
+    return textureLoad(src, coord, 0);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn cs_main(@builtin(global_invocation_id) id: vec3u) {
+    if (id.x >= params.dstSize.x || id.y >= params.dstSize.y) {
+        return;
+    }
+
+    let dstCenter = vec2f(vec2u(id.xy)) + vec2f(0.5, 0.5);
+    let srcPixel = clamp(vec2i(floor(params.offset + dstCenter * params.scale)), vec2i(0, 0),
+                         vec2i(params.srcSize) - vec2i(1, 1));
+    let depth = load_depth(srcPixel);
+    out_z[id.y * params.dstSize.x + id.x] = gx_z24(depth);
+}
+)"sv;
+
+std::string build_shader_source(bool multisampled) {
+  const auto& main = multisampled ? ShaderMainMS : ShaderMain;
   std::string source;
-  source.reserve(ShaderPreamble.size() + ReversedZBody.size() + ShaderMain.size());
+  source.reserve(ShaderPreamble.size() + ReversedZBody.size() + main.size());
   source += ShaderPreamble;
   source += gx::UseReversedZ ? ReversedZBody : ForwardZBody;
-  source += ShaderMain;
+  source += main;
   return source;
 }
 
-wgpu::ComputePipeline create_pipeline(const wgpu::BindGroupLayout& bindGroupLayout, const char* label) {
-  const auto shaderSource = build_shader_source();
+wgpu::ComputePipeline create_pipeline(
+    const wgpu::BindGroupLayout& bindGroupLayout, const char* label, bool multisampled) {
+  const auto shaderSource = build_shader_source(multisampled);
   const wgpu::ShaderSourceWGSL wgslSource{wgpu::ShaderSourceWGSL::Init{
       .code = shaderSource.c_str(),
   }};
@@ -163,8 +189,8 @@ wgpu::ComputePipeline create_pipeline(const wgpu::BindGroupLayout& bindGroupLayo
   return g_device.CreateComputePipeline(&pipelineDescriptor);
 }
 
-wgpu::BindGroupLayout create_bind_group_layout(const char* label) {
-  constexpr std::array entries{
+wgpu::BindGroupLayout create_bind_group_layout(const char* label, bool multisampled) {
+  const std::array entries{
       wgpu::BindGroupLayoutEntry{
           .binding = 0,
           .visibility = wgpu::ShaderStage::Compute,
@@ -172,6 +198,7 @@ wgpu::BindGroupLayout create_bind_group_layout(const char* label) {
               wgpu::TextureBindingLayout{
                   .sampleType = wgpu::TextureSampleType::Depth,
                   .viewDimension = wgpu::TextureViewDimension::e2D,
+                  .multisampled = multisampled,
               },
       },
       wgpu::BindGroupLayoutEntry{
@@ -309,8 +336,10 @@ void initialize() {
   if (!webgpu::g_hasCoreFeatures) {
     return;
   }
-  g_bindGroupLayout = create_bind_group_layout("Depth Peek Bind Group Layout");
-  g_pipeline = create_pipeline(g_bindGroupLayout, "Depth Peek Pipeline");
+  g_bindGroupLayout = create_bind_group_layout("Depth Peek Bind Group Layout", false);
+  g_pipeline = create_pipeline(g_bindGroupLayout, "Depth Peek Pipeline", false);
+  g_bindGroupLayoutMS = create_bind_group_layout("Depth Peek Bind Group Layout MS", true);
+  g_pipelineMS = create_pipeline(g_bindGroupLayoutMS, "Depth Peek Pipeline MS", true);
   g_enabled = true;
 }
 
@@ -318,6 +347,8 @@ void shutdown() {
   testing::reset();
   g_pipeline = {};
   g_bindGroupLayout = {};
+  g_pipelineMS = {};
+  g_bindGroupLayoutMS = {};
   for (auto& slot : g_slots) {
     slot = {};
   }
@@ -361,9 +392,7 @@ void encode_frame_snapshot(const wgpu::CommandEncoder& cmd, const wgpu::TextureV
   if (!depthView || dstSize.x == 0 || dstSize.y == 0 || sourceSize.width == 0 || sourceSize.height == 0) {
     return;
   }
-  if (msaaSamples > 1) {
-    Log.fatal("Depth Peek from multisampled EFB targets is not supported");
-  }
+  const bool multisampled = msaaSamples > 1;
 
   const Params params = make_params(sourceSize, dstSize);
   wgpu::Buffer storageBuffer;
@@ -404,7 +433,7 @@ void encode_frame_snapshot(const wgpu::CommandEncoder& cmd, const wgpu::TextureV
   };
   const wgpu::BindGroupDescriptor bindGroupDescriptor{
       .label = "Depth Peek Bind Group",
-      .layout = g_bindGroupLayout,
+      .layout = multisampled ? g_bindGroupLayoutMS : g_bindGroupLayout,
       .entryCount = bindGroupEntries.size(),
       .entries = bindGroupEntries.data(),
   };
@@ -415,7 +444,7 @@ void encode_frame_snapshot(const wgpu::CommandEncoder& cmd, const wgpu::TextureV
       .timestampWrites = webgpu::gpu_prof::pass_writes("Depth peek"),
   };
   const auto pass = cmd.BeginComputePass(&passDescriptor);
-  pass.SetPipeline(g_pipeline);
+  pass.SetPipeline(multisampled ? g_pipelineMS : g_pipeline);
   pass.SetBindGroup(0, bindGroup);
   pass.DispatchWorkgroups((dstSize.x + WorkgroupSizeX - 1) / WorkgroupSizeX,
                           (dstSize.y + WorkgroupSizeY - 1) / WorkgroupSizeY);

--- a/lib/gfx/encoding.cpp
+++ b/lib/gfx/encoding.cpp
@@ -262,15 +262,13 @@ void render(wgpu::CommandEncoder& cmd, FramePacket& frame, RenderPass& passInfo,
     const bool needsScaling = dstSize.width != static_cast<uint32_t>(passInfo.resolveRect.width) ||
                               dstSize.height != static_cast<uint32_t>(passInfo.resolveRect.height);
     const bool isDepth = gx::is_depth_format(passInfo.resolveFormat);
-    if (isDepth && passInfo.msaaSamples > 1) {
-      Log.fatal("Depth tex copies from multisampled EFB targets are not supported");
-    }
     const tex_copy_conv::ConvRequest convReq{
         .fmt = passInfo.resolveFormat,
         .srcView = isDepth ? passInfo.copySourceDepthView : passInfo.copySourceView,
         .uniformRange = passInfo.resolveUniformRange,
         .dst = passInfo.resolveTarget,
         .sampleFilter = needsScaling ? tex_copy_conv::SampleFilter::Linear : tex_copy_conv::SampleFilter::Nearest,
+        .msaaSamples = isDepth ? passInfo.msaaSamples : 1,
     };
     if (needsConversion) {
       tex_copy_conv::run(cmd, convReq);

--- a/lib/gfx/tex_copy_conv.cpp
+++ b/lib/gfx/tex_copy_conv.cpp
@@ -111,6 +111,58 @@ fn gx_z24(uv: vec2f) -> u32 {
 }
 )"s);
 
+// Multisampled variant of DepthShaderPreamble: reads the multisampled EFB depth buffer at
+// sample index 0. gx_z24() bodies are shared with the single-sample preamble below since
+// textureLoad(src, coord, 0) has the same call shape for both texture_depth_2d (mip level)
+// and texture_depth_multisampled_2d (sample index).
+static const std::string DepthShaderPreambleMS = R"(
+@group(0) @binding(0) var src: texture_depth_multisampled_2d;
+
+struct UVTransform {
+    offset: vec2f,
+    scale: vec2f,
+};
+@group(0) @binding(1) var<uniform> uv_xf: UVTransform;
+
+struct VertexOutput {
+    @builtin(position) pos: vec4f,
+    @location(0) uv: vec2f,
+};
+
+var<private> positions: array<vec2f, 3> = array(
+    vec2f(-1.0, 1.0),
+    vec2f(-1.0, -3.0),
+    vec2f(3.0, 1.0),
+);
+var<private> uvs: array<vec2f, 3> = array(
+    vec2f(0.0, 0.0),
+    vec2f(0.0, 2.0),
+    vec2f(2.0, 0.0),
+);
+
+@vertex fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
+    var out: VertexOutput;
+    out.pos = vec4f(positions[vi], 0.0, 1.0);
+    out.uv = uvs[vi] * uv_xf.scale + uv_xf.offset;
+    return out;
+}
+)"s + (gx::UseReversedZ ? R"(
+fn gx_z24(uv: vec2f) -> u32 {
+    let texSize = vec2i(textureDimensions(src));
+    let coord = clamp(vec2i(floor(uv * vec2f(texSize))), vec2i(0), texSize - vec2i(1));
+    let depth = textureLoad(src, coord, 0);
+    return min(u32(clamp(1.0 - depth, 0.0, 1.0) * 16777215.0 + 0.5), 0x00ffffffu);
+}
+)"s
+                          : R"(
+fn gx_z24(uv: vec2f) -> u32 {
+    let texSize = vec2i(textureDimensions(src));
+    let coord = clamp(vec2i(floor(uv * vec2f(texSize))), vec2i(0), texSize - vec2i(1));
+    let depth = textureLoad(src, coord, 0);
+    return min(u32(clamp(depth, 0.0, 1.0) * 16777215.0 + 0.5), 0x00ffffffu);
+}
+)"s);
+
 // Passthrough blit (for scaling)
 static constexpr std::string_view FragPassthrough = R"(
 @fragment fn fs_main(in: VertexOutput) -> @location(0) vec4f {
@@ -324,9 +376,11 @@ static constexpr std::array DepthConvPipelines{
 
 static wgpu::BindGroupLayout g_bindGroupLayout;
 static wgpu::BindGroupLayout g_depthBindGroupLayout;
+static wgpu::BindGroupLayout g_depthBindGroupLayoutMS;
 static wgpu::Sampler g_nearestSampler;
 static wgpu::Sampler g_linearSampler;
 static absl::flat_hash_map<GXTexFmt, wgpu::RenderPipeline> g_pipelines;
+static absl::flat_hash_map<GXTexFmt, wgpu::RenderPipeline> g_depthPipelinesMS;
 static wgpu::RenderPipeline g_blitPipeline;
 static wgpu::BindGroupLayout g_depthSnapshotBindGroupLayout;
 static wgpu::BindGroupLayout g_depthSnapshotBindGroupLayoutMS;
@@ -510,6 +564,33 @@ void initialize() {
   };
   g_depthBindGroupLayout = g_device.CreateBindGroupLayout(&depthBindGroupLayoutDescriptor);
 
+  static constexpr std::array depthBindGroupLayoutEntriesMS{
+      wgpu::BindGroupLayoutEntry{
+          .binding = 0,
+          .visibility = wgpu::ShaderStage::Fragment,
+          .texture =
+              wgpu::TextureBindingLayout{
+                  .sampleType = wgpu::TextureSampleType::Depth,
+                  .viewDimension = wgpu::TextureViewDimension::e2D,
+                  .multisampled = true,
+              },
+      },
+      wgpu::BindGroupLayoutEntry{
+          .binding = 1,
+          .visibility = wgpu::ShaderStage::Vertex,
+          .buffer =
+              wgpu::BufferBindingLayout{
+                  .type = wgpu::BufferBindingType::Uniform,
+              },
+      },
+  };
+  static constexpr wgpu::BindGroupLayoutDescriptor depthBindGroupLayoutDescriptorMS{
+      .label = "TexCopyConv Depth Bind Group Layout MS",
+      .entryCount = depthBindGroupLayoutEntriesMS.size(),
+      .entries = depthBindGroupLayoutEntriesMS.data(),
+  };
+  g_depthBindGroupLayoutMS = g_device.CreateBindGroupLayout(&depthBindGroupLayoutDescriptorMS);
+
   g_blitPipeline = create_pipeline(
       {GX_TF_RGBA8, FragPassthrough, webgpu::g_graphicsConfig.surfaceConfiguration.format, "TexCopyConv Blit"},
       ShaderPreamble, g_bindGroupLayout);
@@ -526,6 +607,9 @@ void initialize() {
       if (conv.outputFormat != to_wgpu(conv.fmt)) {
         Log.fatal("Output format mismatch for {}", conv.fmt);
       }
+    }
+    for (const auto& conv : DepthConvPipelines) {
+      g_depthPipelinesMS[conv.fmt] = create_pipeline(conv, DepthShaderPreambleMS, g_depthBindGroupLayoutMS);
     }
     g_depthSnapshotBindGroupLayout = create_depth_snapshot_layout(false, "Depth Snapshot Bind Group Layout");
     g_depthSnapshotBindGroupLayoutMS = create_depth_snapshot_layout(true, "Depth Snapshot MS Bind Group Layout");
@@ -552,9 +636,11 @@ void initialize() {
 
 void shutdown() {
   g_pipelines.clear();
+  g_depthPipelinesMS.clear();
   g_blitPipeline = {};
   g_bindGroupLayout = {};
   g_depthBindGroupLayout = {};
+  g_depthBindGroupLayoutMS = {};
   g_nearestSampler = {};
   g_linearSampler = {};
   g_depthSnapshotBindGroupLayout = {};
@@ -586,7 +672,7 @@ static void execute(const wgpu::CommandEncoder& cmd, const ConvRequest& req, con
         },
     };
     const wgpu::BindGroupDescriptor bindGroupDescriptor{
-        .layout = g_depthBindGroupLayout,
+        .layout = req.msaaSamples > 1 ? g_depthBindGroupLayoutMS : g_depthBindGroupLayout,
         .entryCount = bindGroupEntries.size(),
         .entries = bindGroupEntries.data(),
     };
@@ -639,8 +725,10 @@ static void execute(const wgpu::CommandEncoder& cmd, const ConvRequest& req, con
 }
 
 void run(const wgpu::CommandEncoder& cmd, const ConvRequest& req) {
-  const auto it = g_pipelines.find(req.fmt);
-  if (it == g_pipelines.end()) {
+  const bool useMS = req.msaaSamples > 1 && gx::is_depth_format(req.fmt);
+  auto& pipelines = useMS ? g_depthPipelinesMS : g_pipelines;
+  const auto it = pipelines.find(req.fmt);
+  if (it == pipelines.end()) {
     Log.fatal("No copy conversion pipeline for format {}", static_cast<int>(req.fmt));
   }
   execute(cmd, req, it->second);

--- a/lib/gfx/tex_copy_conv.hpp
+++ b/lib/gfx/tex_copy_conv.hpp
@@ -17,6 +17,7 @@ struct ConvRequest {
   Range uniformRange;        // UV transform uniform (offset + scale)
   TextureHandle dst;         // Destination texture
   SampleFilter sampleFilter = SampleFilter::Nearest;
+  uint32_t msaaSamples = 1; // For depth formats: srcView is multisampled and read at sample index 0
 };
 
 bool needs_conversion(GXTexFmt fmt);

--- a/lib/rmlui.cpp
+++ b/lib/rmlui.cpp
@@ -465,7 +465,7 @@ RecordedFrame record_frame(const webgpu::Viewport& presentViewport) noexcept {
 
   auto* renderInterface = get_render_interface();
   renderInterface->SetWindowSize(g_context->GetDimensions());
-  renderInterface->BeginFrame(s_renderTarget, webgpu::aa_present_source(),
+  renderInterface->BeginFrame(s_renderTarget, webgpu::present_source(),
                               needsBackdrop ? BaseLayerContent::Scene : BaseLayerContent::Transparent);
 
   Backend::BeginFrame();

--- a/lib/rmlui.cpp
+++ b/lib/rmlui.cpp
@@ -465,7 +465,7 @@ RecordedFrame record_frame(const webgpu::Viewport& presentViewport) noexcept {
 
   auto* renderInterface = get_render_interface();
   renderInterface->SetWindowSize(g_context->GetDimensions());
-  renderInterface->BeginFrame(s_renderTarget, webgpu::present_source(),
+  renderInterface->BeginFrame(s_renderTarget, webgpu::aa_present_source(),
                               needsBackdrop ? BaseLayerContent::Scene : BaseLayerContent::Transparent);
 
   Backend::BeginFrame();

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -249,19 +249,19 @@ fn vs_main(@builtin(vertex_index) vtxIdx: u32) -> VertexOutput {
 }
 
 // Timothy Lottes' widely-deployed reduced FXAA (the "FXAA Console" shader behind e.g. three.js's
-// FXAA pass and most glsl-fxaa ports): unlike a threshold-gated blur that only fires above a
-// fixed contrast cutoff (which either blurs everywhere at a low threshold or barely touches real
-// edges at a properly-conservative one), this computes a continuous 2D gradient direction from
-// the 4 diagonal neighbors and walks the sample point along *that* direction. A diagonal
-// stair-step edge gets a diagonal sample direction and is actually smoothed; a flat region has
-// ~zero gradient, so the walk collapses to sampling the same texel twice and the pixel is
-// untouched -- self-limiting without a separate edge/no-edge gate.
-// Deliberately branchless (all textureSample() calls unconditional, `select()` instead of `if`):
-// WGSL requires textureSample() to run in uniform control flow, so gating one behind a
-// data-dependent branch is a validation error.
+// FXAA pass and most glsl-fxaa ports), with the edge-threshold early-out from full FXAA 3.11
+// restored below: without it, FXAA_REDUCE_MIN keeps `dir` nonzero for *any* nonzero luma delta
+// among the 4 diagonal samples, and real textures (grass, rock, wood grain) have that virtually
+// everywhere, not just on geometry silhouettes -- so the tent-filter blend below fired on ~every
+// pixel and softened the whole frame instead of just stairstepped edges. The lumaRange check
+// gates the *output* (via select on the fully-computed finalColor), not the sampling, so it stays
+// branchless: WGSL requires textureSample() to run in uniform control flow, so gating one behind
+// a data-dependent branch is a validation error, but `select()` on already-computed values is not.
 const FXAA_REDUCE_MIN: f32 = 1.0 / 128.0;
 const FXAA_REDUCE_MUL: f32 = 1.0 / 8.0;
 const FXAA_SPAN_MAX: f32 = 8.0;
+const FXAA_EDGE_THRESHOLD_MIN: f32 = 0.0312;
+const FXAA_EDGE_THRESHOLD_MAX: f32 = 0.125;
 
 fn fxaa_luma(c: vec3<f32>) -> f32 {
     return dot(c, vec3<f32>(0.299, 0.587, 0.114));
@@ -304,7 +304,11 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
     let lumaB = fxaa_luma(rgbB);
     let outOfRange = lumaB < lumaMin || lumaB > lumaMax;
-    let finalColor = select(rgbB, rgbA, outOfRange);
+    let blended = select(rgbB, rgbA, outOfRange);
+
+    let lumaRange = lumaMax - lumaMin;
+    let isEdge = lumaRange >= max(FXAA_EDGE_THRESHOLD_MIN, lumaMax * FXAA_EDGE_THRESHOLD_MAX);
+    let finalColor = select(rgbM, blended, isEdge);
     return vec4<f32>(finalColor, 1.0);
 }
 )"sv;

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <span>
 #include <string>
 #include <string_view>
@@ -59,6 +60,22 @@ static wgpu::BindGroupLayout g_ResampleBindGroupLayout;
 static wgpu::RenderPipeline g_ResamplePipeline;
 static wgpu::Buffer g_ResampleUniformBuffer;
 static TextureWithSampler g_resampledFrameBuffer;
+
+// FXAA post-process pass. Queued as a gfx encoder task from the game's FRAME_AFTER_HUD hook (the
+// only point in the frame with an active EFB pass to snapshot -- see aurora_queue_fxaa_pass's doc
+// comment), rather than appended to the tail-end present blit: RmlUI composites its own backdrop
+// (blurred menus, popups) from present_source() *before* that tail-end blit ever runs, so an FXAA
+// pass placed there would never be visible behind such UI. g_fxaaQueued is main-thread-only (set in
+// queue_fxaa_pass(), read by aa_present_source(), both called in frame order from the main thread)
+// so it doesn't need atomic access, unlike g_fxaaEnabled which is also flipped from the UI thread.
+static std::atomic_bool g_fxaaEnabled = false;
+static bool g_fxaaQueued = false;
+static gfx::EncoderTaskId g_FxaaTaskId = gfx::InvalidEncoderTask;
+static wgpu::BindGroupLayout g_FxaaBindGroupLayout;
+static wgpu::RenderPipeline g_FxaaPipeline;
+static wgpu::Buffer g_FxaaUniformBuffer;
+static wgpu::Sampler g_FxaaSourceSampler;
+static TextureWithSampler g_fxaaFrameBuffer;
 
 static wgpu::Adapter g_adapter;
 wgpu::Instance g_instance;
@@ -192,6 +209,105 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 }
 )"sv;
 
+struct FxaaUniformBlock {
+  float texelWidth = 0.f;
+  float texelHeight = 0.f;
+};
+
+constexpr std::string_view fxaaShaderSource = R"(
+struct Uniforms {
+    texel_size: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var s: sampler;
+@group(0) @binding(2) var t: texture_2d<f32>;
+
+var<private> pos: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+    vec2(-1.0, 1.0),
+    vec2(-1.0, -3.0),
+    vec2(3.0, 1.0),
+);
+var<private> uvs: array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+    vec2(0.0, 0.0),
+    vec2(0.0, 2.0),
+    vec2(2.0, 0.0),
+);
+
+@vertex
+fn vs_main(@builtin(vertex_index) vtxIdx: u32) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = vec4<f32>(pos[vtxIdx], 0.0, 1.0);
+    out.uv = uvs[vtxIdx];
+    return out;
+}
+
+// Timothy Lottes' widely-deployed reduced FXAA (the "FXAA Console" shader behind e.g. three.js's
+// FXAA pass and most glsl-fxaa ports): unlike a threshold-gated blur that only fires above a
+// fixed contrast cutoff (which either blurs everywhere at a low threshold or barely touches real
+// edges at a properly-conservative one), this computes a continuous 2D gradient direction from
+// the 4 diagonal neighbors and walks the sample point along *that* direction. A diagonal
+// stair-step edge gets a diagonal sample direction and is actually smoothed; a flat region has
+// ~zero gradient, so the walk collapses to sampling the same texel twice and the pixel is
+// untouched -- self-limiting without a separate edge/no-edge gate.
+// Deliberately branchless (all textureSample() calls unconditional, `select()` instead of `if`):
+// WGSL requires textureSample() to run in uniform control flow, so gating one behind a
+// data-dependent branch is a validation error.
+const FXAA_REDUCE_MIN: f32 = 1.0 / 128.0;
+const FXAA_REDUCE_MUL: f32 = 1.0 / 8.0;
+const FXAA_SPAN_MAX: f32 = 8.0;
+
+fn fxaa_luma(c: vec3<f32>) -> f32 {
+    return dot(c, vec3<f32>(0.299, 0.587, 0.114));
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let texel = uniforms.texel_size;
+    let uv = in.uv;
+
+    let rgbNW = textureSample(t, s, uv + vec2<f32>(-texel.x, -texel.y)).rgb;
+    let rgbNE = textureSample(t, s, uv + vec2<f32>(texel.x, -texel.y)).rgb;
+    let rgbSW = textureSample(t, s, uv + vec2<f32>(-texel.x, texel.y)).rgb;
+    let rgbSE = textureSample(t, s, uv + vec2<f32>(texel.x, texel.y)).rgb;
+    let rgbM = textureSample(t, s, uv).rgb;
+
+    let lumaNW = fxaa_luma(rgbNW);
+    let lumaNE = fxaa_luma(rgbNE);
+    let lumaSW = fxaa_luma(rgbSW);
+    let lumaSE = fxaa_luma(rgbSE);
+    let lumaM = fxaa_luma(rgbM);
+
+    let lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+    let lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+
+    var dir = vec2<f32>(
+        -((lumaNW + lumaNE) - (lumaSW + lumaSE)),
+        ((lumaNW + lumaSW) - (lumaNE + lumaSE)));
+
+    let dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * FXAA_REDUCE_MUL), FXAA_REDUCE_MIN);
+    let rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+    dir = clamp(dir * rcpDirMin, vec2<f32>(-FXAA_SPAN_MAX), vec2<f32>(FXAA_SPAN_MAX)) * texel;
+
+    let rgbA = 0.5 * (
+        textureSample(t, s, uv + dir * (1.0 / 3.0 - 0.5)).rgb +
+        textureSample(t, s, uv + dir * (2.0 / 3.0 - 0.5)).rgb);
+    let rgbB = rgbA * 0.5 + 0.25 * (
+        textureSample(t, s, uv + dir * -0.5).rgb +
+        textureSample(t, s, uv + dir * 0.5).rgb);
+
+    let lumaB = fxaa_luma(rgbB);
+    let outOfRange = lumaB < lumaMin || lumaB > lumaMax;
+    let finalColor = select(rgbB, rgbA, outOfRange);
+    return vec4<f32>(finalColor, 1.0);
+}
+)"sv;
+
 wgpu::TextureFormat to_linear(wgpu::TextureFormat format) {
   if (format == wgpu::TextureFormat::RGBA8UnormSrgb) {
     return wgpu::TextureFormat::RGBA8Unorm;
@@ -318,6 +434,13 @@ const TextureWithSampler& present_source() noexcept {
   return g_graphicsConfig.msaaSamples > 1 ? g_frameBufferResolved : g_frameBuffer;
 }
 
+const TextureWithSampler& aa_present_source() noexcept {
+  if (g_fxaaQueued) {
+    return g_fxaaFrameBuffer;
+  }
+  return present_source();
+}
+
 void set_resampler(AuroraSampler sampler) noexcept {
   switch (sampler) {
   case SAMPLER_AREA:
@@ -331,6 +454,8 @@ void set_resampler(AuroraSampler sampler) noexcept {
 }
 
 AuroraSampler get_resampler() noexcept { return g_Resampler; }
+
+void set_fxaa_enabled(bool enabled) noexcept { g_fxaaEnabled.store(enabled, std::memory_order_relaxed); }
 
 Viewport calculate_present_viewport(uint32_t surface_width, uint32_t surface_height, uint32_t content_width,
                                     uint32_t content_height) noexcept {
@@ -623,6 +748,102 @@ void create_resample_pipeline() {
   g_ResampleUniformBuffer = g_device.CreateBuffer(&uniformBufferDescriptor);
 }
 
+void create_fxaa_pipeline() {
+  wgpu::ShaderSourceWGSL sourceDescriptor{};
+  sourceDescriptor.code = fxaaShaderSource;
+  const wgpu::ShaderModuleDescriptor moduleDescriptor{
+      .nextInChain = &sourceDescriptor,
+      .label = "FXAA Module",
+  };
+  auto module = g_device.CreateShaderModule(&moduleDescriptor);
+  const std::array colorTargets{wgpu::ColorTargetState{
+      .format = g_graphicsConfig.surfaceConfiguration.format,
+      .writeMask = wgpu::ColorWriteMask::All,
+  }};
+  const wgpu::FragmentState fragmentState{
+      .module = module,
+      .entryPoint = "fs_main",
+      .targetCount = colorTargets.size(),
+      .targets = colorTargets.data(),
+  };
+  const std::array bindGroupLayoutEntries{
+      wgpu::BindGroupLayoutEntry{
+          .binding = 0,
+          .visibility = wgpu::ShaderStage::Fragment,
+          .buffer =
+              wgpu::BufferBindingLayout{
+                  .type = wgpu::BufferBindingType::Uniform,
+              },
+      },
+      wgpu::BindGroupLayoutEntry{
+          .binding = 1,
+          .visibility = wgpu::ShaderStage::Fragment,
+          .sampler =
+              wgpu::SamplerBindingLayout{
+                  .type = wgpu::SamplerBindingType::Filtering,
+              },
+      },
+      wgpu::BindGroupLayoutEntry{
+          .binding = 2,
+          .visibility = wgpu::ShaderStage::Fragment,
+          .texture =
+              wgpu::TextureBindingLayout{
+                  .sampleType = wgpu::TextureSampleType::Float,
+                  .viewDimension = wgpu::TextureViewDimension::e2D,
+              },
+      },
+  };
+  const wgpu::BindGroupLayoutDescriptor bindGroupLayoutDescriptor{
+      .entryCount = bindGroupLayoutEntries.size(),
+      .entries = bindGroupLayoutEntries.data(),
+  };
+  g_FxaaBindGroupLayout = g_device.CreateBindGroupLayout(&bindGroupLayoutDescriptor);
+  const wgpu::PipelineLayoutDescriptor layoutDescriptor{
+      .bindGroupLayoutCount = 1,
+      .bindGroupLayouts = &g_FxaaBindGroupLayout,
+  };
+  auto pipelineLayout = g_device.CreatePipelineLayout(&layoutDescriptor);
+  const wgpu::RenderPipelineDescriptor pipelineDescriptor{
+      .label = "FXAA Pipeline",
+      .layout = pipelineLayout,
+      .vertex =
+          wgpu::VertexState{
+              .module = module,
+              .entryPoint = "vs_main",
+          },
+      .primitive =
+          wgpu::PrimitiveState{
+              .topology = wgpu::PrimitiveTopology::TriangleList,
+          },
+      .multisample =
+          wgpu::MultisampleState{
+              .count = 1,
+              .mask = UINT32_MAX,
+          },
+      .fragment = &fragmentState,
+  };
+  g_FxaaPipeline = g_device.CreateRenderPipeline(&pipelineDescriptor);
+
+  const wgpu::BufferDescriptor uniformBufferDescriptor{
+      .label = "FXAA Uniform Buffer",
+      .usage = wgpu::BufferUsage::CopyDst | wgpu::BufferUsage::Uniform,
+      .size = AURORA_ALIGN(sizeof(FxaaUniformBlock), 16),
+  };
+  g_FxaaUniformBuffer = g_device.CreateBuffer(&uniformBufferDescriptor);
+
+  // Source view comes from gfx::resolve_pass(), a bare wgpu::TextureView with no paired sampler
+  // (unlike the TextureWithSampler sources resample/copy sample from), so FXAA needs its own.
+  constexpr wgpu::SamplerDescriptor samplerDescriptor{
+      .label = "FXAA Source Sampler",
+      .addressModeU = wgpu::AddressMode::ClampToEdge,
+      .addressModeV = wgpu::AddressMode::ClampToEdge,
+      .addressModeW = wgpu::AddressMode::ClampToEdge,
+      .magFilter = wgpu::FilterMode::Linear,
+      .minFilter = wgpu::FilterMode::Linear,
+  };
+  g_FxaaSourceSampler = g_device.CreateSampler(&samplerDescriptor);
+}
+
 wgpu::BindGroup create_copy_bind_group(const TextureWithSampler& source) {
   const std::array bindGroupEntries{
       wgpu::BindGroupEntry{
@@ -643,7 +864,7 @@ wgpu::BindGroup create_copy_bind_group(const TextureWithSampler& source) {
 }
 
 const TextureWithSampler& resample_present_source(const wgpu::CommandEncoder& encoder, const Viewport& viewport) {
-  const auto& source = present_source();
+  const auto& source = aa_present_source();
   const uint32_t width = viewport_extent(viewport.width);
   const uint32_t height = viewport_extent(viewport.height);
   if (!g_resampledFrameBuffer.view || g_resampledFrameBuffer.size.width != width ||
@@ -704,6 +925,127 @@ const TextureWithSampler& resample_present_source(const wgpu::CommandEncoder& en
   return g_resampledFrameBuffer;
 }
 
+namespace {
+
+// Carries the resolve_pass() snapshot from queue_fxaa_pass() (main thread, called from the game's
+// FRAME_AFTER_HUD hook, while the EFB pass is still open) across to fxaa_encoder_task_callback()
+// (render worker, fires once this frame's ops reach this point). colorView holds the one extra ref
+// AddRef'd in queue_fxaa_pass(); the callback consumes it via wgpu::TextureView::Acquire(), mirroring
+// save_state::thumbnail_capture's CapturePayload pattern for the same reason (Dawn's C++ callback
+// wrapper only supports trivial captures, not a refcounted wgpu::TextureView).
+struct FxaaTaskPayload {
+  WGPUTextureView colorView = nullptr;
+  uint32_t width = 0;
+  uint32_t height = 0;
+};
+
+void fxaa_encoder_task_callback(const gfx::EncoderTaskContext& ctx, const wgpu::CommandEncoder& cmd,
+    const void* payload, size_t payloadSize, void*) {
+  if (payloadSize != sizeof(FxaaTaskPayload)) {
+    return;
+  }
+  FxaaTaskPayload task;
+  std::memcpy(&task, payload, sizeof(task));
+  auto sourceView = wgpu::TextureView::Acquire(task.colorView);
+  if (!sourceView || task.width == 0 || task.height == 0) {
+    return;
+  }
+
+  if (!g_fxaaFrameBuffer.view || g_fxaaFrameBuffer.size.width != task.width ||
+      g_fxaaFrameBuffer.size.height != task.height) {
+    g_fxaaFrameBuffer = create_render_texture(task.width, task.height, false);
+  }
+
+  const FxaaUniformBlock uniform{
+      .texelWidth = 1.f / static_cast<float>(task.width),
+      .texelHeight = 1.f / static_cast<float>(task.height),
+  };
+  ctx.queue.WriteBuffer(g_FxaaUniformBuffer, 0, &uniform, sizeof(uniform));
+
+  const std::array bindGroupEntries{
+      wgpu::BindGroupEntry{
+          .binding = 0,
+          .buffer = g_FxaaUniformBuffer,
+          .size = AURORA_ALIGN(sizeof(FxaaUniformBlock), 16),
+      },
+      wgpu::BindGroupEntry{
+          .binding = 1,
+          .sampler = g_FxaaSourceSampler,
+      },
+      wgpu::BindGroupEntry{
+          .binding = 2,
+          .textureView = sourceView,
+      },
+  };
+  const wgpu::BindGroupDescriptor bindGroupDescriptor{
+      .layout = g_FxaaBindGroupLayout,
+      .entryCount = bindGroupEntries.size(),
+      .entries = bindGroupEntries.data(),
+  };
+  const auto bindGroup = ctx.device.CreateBindGroup(&bindGroupDescriptor);
+
+  const std::array attachments{
+      wgpu::RenderPassColorAttachment{
+          .view = g_fxaaFrameBuffer.view,
+          .loadOp = wgpu::LoadOp::Clear,
+          .storeOp = wgpu::StoreOp::Store,
+      },
+  };
+  const wgpu::RenderPassDescriptor renderPassDescriptor{
+      .label = "FXAA render pass",
+      .colorAttachmentCount = attachments.size(),
+      .colorAttachments = attachments.data(),
+      .timestampWrites = gpu_prof::pass_writes("FXAA"),
+  };
+  const auto pass = cmd.BeginRenderPass(&renderPassDescriptor);
+  pass.SetPipeline(g_FxaaPipeline);
+  pass.SetBindGroup(0, bindGroup, 0, nullptr);
+  pass.SetViewport(0.f, 0.f, static_cast<float>(task.width), static_cast<float>(task.height), 0.f, 1.f);
+  pass.Draw(3);
+  pass.End();
+}
+
+bool ensure_fxaa_task_registered() {
+  if (g_FxaaTaskId != gfx::InvalidEncoderTask) {
+    return true;
+  }
+  g_FxaaTaskId = gfx::register_encoder_task_type(gfx::EncoderTaskDescriptor{
+      .label = "FXAA",
+      .callback = fxaa_encoder_task_callback,
+  });
+  return g_FxaaTaskId != gfx::InvalidEncoderTask;
+}
+
+} // namespace
+
+void queue_fxaa_pass() noexcept {
+  g_fxaaQueued = false;
+  if (!g_fxaaEnabled.load(std::memory_order_relaxed) || !ensure_fxaa_task_registered()) {
+    return;
+  }
+
+  gfx::ResolvedTargets resolved;
+  if (!gfx::resolve_pass(gfx::ResolveDesc{.color = true}, resolved) || !resolved.color) {
+    return;
+  }
+  // resolve_pass()'s pooled view is owned by `resolved`, which goes out of scope at the end of
+  // this function -- long before fxaa_encoder_task_callback() actually runs (it fires later, from
+  // the render worker, once this frame is being encoded). AddRef an extra reference for the
+  // payload to carry across that gap; the callback wraps it with wgpu::TextureView::Acquire(),
+  // whose destructor releases exactly that extra reference.
+  wgpuTextureViewAddRef(resolved.color.Get());
+  const FxaaTaskPayload payload{
+      .colorView = resolved.color.Get(),
+      .width = resolved.width,
+      .height = resolved.height,
+  };
+  if (!gfx::push_encoder_task(g_FxaaTaskId, &payload, sizeof(payload))) {
+    wgpuTextureViewRelease(payload.colorView);
+    return;
+  }
+  g_fxaaQueued = true;
+}
+
 static wgpu::BackendType to_wgpu_backend(AuroraBackend backend) {
   switch (backend) {
   case BACKEND_WEBGPU:
@@ -746,6 +1088,51 @@ static bool create_surface() {
     return false;
   }
   return true;
+}
+
+// WebGPU only guarantees 1x and 4x sample counts across all backends/adapters; other counts
+// (2x, 8x, ...) are backend- and adapter-dependent, so probe before committing to one.
+static bool msaa_sample_count_supported(uint32_t count, wgpu::TextureFormat format) {
+  const wgpu::Extent3D size{.width = 4, .height = 4, .depthOrArrayLayers = 1};
+  const wgpu::TextureDescriptor textureDescriptor{
+      .label = "MSAA capability probe",
+      .usage = wgpu::TextureUsage::RenderAttachment,
+      .dimension = wgpu::TextureDimension::e2D,
+      .size = size,
+      .format = format,
+      .mipLevelCount = 1,
+      .sampleCount = count,
+  };
+  g_device.PushErrorScope(wgpu::ErrorFilter::Validation);
+  auto texture = g_device.CreateTexture(&textureDescriptor);
+  bool supported = false;
+  const auto future = g_device.PopErrorScope(wgpu::CallbackMode::WaitAnyOnly,
+      [&](wgpu::PopErrorScopeStatus status, wgpu::ErrorType type, wgpu::StringView message) {
+        supported = status == wgpu::PopErrorScopeStatus::Success && type == wgpu::ErrorType::NoError;
+        if (!supported) {
+          Log.warn("{}x MSAA not supported by this adapter: {}", count, message);
+        }
+      });
+  g_instance.WaitAny(future, 5000000000);
+  if (texture) {
+    texture.Destroy();
+  }
+  return supported;
+}
+
+static uint32_t probe_msaa_sample_count(uint32_t requested, wgpu::TextureFormat format) {
+  if (requested <= 1) {
+    return 1;
+  }
+  if (msaa_sample_count_supported(requested, format)) {
+    return requested;
+  }
+  if (requested != 4 && msaa_sample_count_supported(4, format)) {
+    Log.warn("Falling back to 4x MSAA (requested {}x is not supported)", requested);
+    return 4;
+  }
+  Log.warn("Falling back to no MSAA (multisampling is not supported by this adapter)");
+  return 1;
 }
 
 bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
@@ -1039,11 +1426,12 @@ bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
               .presentMode = presentMode,
           },
       .depthFormat = wgpu::TextureFormat::Depth32Float,
-      .msaaSamples = g_config.msaa,
+      .msaaSamples = probe_msaa_sample_count(g_config.msaa, surfaceFormat),
       .textureAnisotropy = g_config.maxTextureAnisotropy,
   };
   create_copy_pipeline();
   create_resample_pipeline();
+  create_fxaa_pipeline();
   gpu_prof::initialize();
   resize_swapchain(size.fb_width, size.fb_height, size.native_fb_width, size.native_fb_height, true);
   g_initialized = true;

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -435,7 +435,15 @@ const TextureWithSampler& present_source() noexcept {
 }
 
 const TextureWithSampler& aa_present_source() noexcept {
-  if (g_fxaaQueued) {
+  // g_fxaaQueued only means the encoder task was successfully enqueued this frame -- its
+  // callback (which actually creates g_fxaaFrameBuffer via create_render_texture) hasn't run
+  // yet, since it's deferred to the render worker. On the first frame FXAA is ever enabled,
+  // g_fxaaFrameBuffer.view is still null at this point: rmlui.cpp reads this synchronously on
+  // the main thread to seed its backdrop, so returning it here would hand RmlUI a null texture
+  // view and crash when it builds a bind group from it. Fall back to present_source() until the
+  // texture actually exists; every later frame it does, since the write always lands before the
+  // ops queue reaches this frame's consumers.
+  if (g_fxaaQueued && g_fxaaFrameBuffer.view) {
     return g_fxaaFrameBuffer;
   }
   return present_source();

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -61,21 +61,22 @@ static wgpu::RenderPipeline g_ResamplePipeline;
 static wgpu::Buffer g_ResampleUniformBuffer;
 static TextureWithSampler g_resampledFrameBuffer;
 
-// FXAA post-process pass. Queued as a gfx encoder task from the game's FRAME_AFTER_HUD hook (the
-// only point in the frame with an active EFB pass to snapshot -- see aurora_queue_fxaa_pass's doc
-// comment), rather than appended to the tail-end present blit: RmlUI composites its own backdrop
-// (blurred menus, popups) from present_source() *before* that tail-end blit ever runs, so an FXAA
-// pass placed there would never be visible behind such UI. g_fxaaQueued is main-thread-only (set in
-// queue_fxaa_pass(), read by aa_present_source(), both called in frame order from the main thread)
-// so it doesn't need atomic access, unlike g_fxaaEnabled which is also flipped from the UI thread.
+// FXAA post-process pass. Injected as a custom draw directly into the EFB pass from the game's
+// FRAME_BEFORE_HUD hook -- i.e. before the 2D HUD (hearts, text, menu icons) is drawn -- so it
+// smooths only the 3D scene in place and the HUD layers on top of it afterward, untouched. This
+// used to run after the HUD instead (as an encoder task swapped in at present time), which (a)
+// blurred HUD text/icons along with real geometry edges, especially visible at 1x internal
+// resolution, and (b) needed a separate aa_present_source() consumers had to remember to call
+// instead of present_source(), which was itself the root of an earlier bug (FXAA invisible behind
+// any backdrop-blurred UI, since RmlUI composited from present_source() before that swap ever
+// ran). Drawing straight into the live EFB pass sidesteps both: present_source() already reflects
+// the antialiased result by the time anything else reads it, so there's nothing to swap.
 static std::atomic_bool g_fxaaEnabled = false;
-static bool g_fxaaQueued = false;
-static gfx::EncoderTaskId g_FxaaTaskId = gfx::InvalidEncoderTask;
+static gfx::DrawTypeId g_FxaaDrawTypeId = gfx::InvalidDrawType;
 static wgpu::BindGroupLayout g_FxaaBindGroupLayout;
 static wgpu::RenderPipeline g_FxaaPipeline;
 static wgpu::Buffer g_FxaaUniformBuffer;
 static wgpu::Sampler g_FxaaSourceSampler;
-static TextureWithSampler g_fxaaFrameBuffer;
 
 static wgpu::Adapter g_adapter;
 wgpu::Instance g_instance;
@@ -432,21 +433,6 @@ TextureWithSampler create_render_texture(uint32_t width, uint32_t height, bool m
 
 const TextureWithSampler& present_source() noexcept {
   return g_graphicsConfig.msaaSamples > 1 ? g_frameBufferResolved : g_frameBuffer;
-}
-
-const TextureWithSampler& aa_present_source() noexcept {
-  // g_fxaaQueued only means the encoder task was successfully enqueued this frame -- its
-  // callback (which actually creates g_fxaaFrameBuffer via create_render_texture) hasn't run
-  // yet, since it's deferred to the render worker. On the first frame FXAA is ever enabled,
-  // g_fxaaFrameBuffer.view is still null at this point: rmlui.cpp reads this synchronously on
-  // the main thread to seed its backdrop, so returning it here would hand RmlUI a null texture
-  // view and crash when it builds a bind group from it. Fall back to present_source() until the
-  // texture actually exists; every later frame it does, since the write always lands before the
-  // ops queue reaches this frame's consumers.
-  if (g_fxaaQueued && g_fxaaFrameBuffer.view) {
-    return g_fxaaFrameBuffer;
-  }
-  return present_source();
 }
 
 void set_resampler(AuroraSampler sampler) noexcept {
@@ -872,7 +858,7 @@ wgpu::BindGroup create_copy_bind_group(const TextureWithSampler& source) {
 }
 
 const TextureWithSampler& resample_present_source(const wgpu::CommandEncoder& encoder, const Viewport& viewport) {
-  const auto& source = aa_present_source();
+  const auto& source = present_source();
   const uint32_t width = viewport_extent(viewport.width);
   const uint32_t height = viewport_extent(viewport.height);
   if (!g_resampledFrameBuffer.view || g_resampledFrameBuffer.size.width != width ||
@@ -936,32 +922,27 @@ const TextureWithSampler& resample_present_source(const wgpu::CommandEncoder& en
 namespace {
 
 // Carries the resolve_pass() snapshot from queue_fxaa_pass() (main thread, called from the game's
-// FRAME_AFTER_HUD hook, while the EFB pass is still open) across to fxaa_encoder_task_callback()
-// (render worker, fires once this frame's ops reach this point). colorView holds the one extra ref
-// AddRef'd in queue_fxaa_pass(); the callback consumes it via wgpu::TextureView::Acquire(), mirroring
+// FRAME_BEFORE_HUD hook, while the EFB pass is still open) across to fxaa_draw_callback() (render
+// worker, fires once this frame's ops reach this point). colorView holds the one extra ref AddRef'd
+// in queue_fxaa_pass(); the callback consumes it via wgpu::TextureView::Acquire(), mirroring
 // save_state::thumbnail_capture's CapturePayload pattern for the same reason (Dawn's C++ callback
 // wrapper only supports trivial captures, not a refcounted wgpu::TextureView).
-struct FxaaTaskPayload {
+struct FxaaDrawPayload {
   WGPUTextureView colorView = nullptr;
   uint32_t width = 0;
   uint32_t height = 0;
 };
 
-void fxaa_encoder_task_callback(const gfx::EncoderTaskContext& ctx, const wgpu::CommandEncoder& cmd,
+void fxaa_draw_callback(const gfx::DrawContext& ctx, const wgpu::RenderPassEncoder& pass,
     const void* payload, size_t payloadSize, void*) {
-  if (payloadSize != sizeof(FxaaTaskPayload)) {
+  if (payloadSize != sizeof(FxaaDrawPayload)) {
     return;
   }
-  FxaaTaskPayload task;
+  FxaaDrawPayload task;
   std::memcpy(&task, payload, sizeof(task));
   auto sourceView = wgpu::TextureView::Acquire(task.colorView);
   if (!sourceView || task.width == 0 || task.height == 0) {
     return;
-  }
-
-  if (!g_fxaaFrameBuffer.view || g_fxaaFrameBuffer.size.width != task.width ||
-      g_fxaaFrameBuffer.size.height != task.height) {
-    g_fxaaFrameBuffer = create_render_texture(task.width, task.height, false);
   }
 
   const FxaaUniformBlock uniform{
@@ -992,43 +973,34 @@ void fxaa_encoder_task_callback(const gfx::EncoderTaskContext& ctx, const wgpu::
   };
   const auto bindGroup = ctx.device.CreateBindGroup(&bindGroupDescriptor);
 
-  const std::array attachments{
-      wgpu::RenderPassColorAttachment{
-          .view = g_fxaaFrameBuffer.view,
-          .loadOp = wgpu::LoadOp::Clear,
-          .storeOp = wgpu::StoreOp::Store,
-      },
-  };
-  const wgpu::RenderPassDescriptor renderPassDescriptor{
-      .label = "FXAA render pass",
-      .colorAttachmentCount = attachments.size(),
-      .colorAttachments = attachments.data(),
-      .timestampWrites = gpu_prof::pass_writes("FXAA"),
-  };
-  const auto pass = cmd.BeginRenderPass(&renderPassDescriptor);
+  // Draws straight into the pass already open at this point in the EFB's command stream -- the
+  // live game framebuffer, still holding only the 3D scene since this fires before the HUD draws
+  // that follow it. No BeginRenderPass/End here: we don't own this pass, we're just injecting a
+  // full-screen opaque triangle that overwrites every covered pixel with the antialiased result.
+  // The caller restores pipeline/bind-group/viewport/scissor state once this returns, so the GX
+  // draws right after (the HUD) aren't affected by any of this.
   pass.SetPipeline(g_FxaaPipeline);
   pass.SetBindGroup(0, bindGroup, 0, nullptr);
   pass.SetViewport(0.f, 0.f, static_cast<float>(task.width), static_cast<float>(task.height), 0.f, 1.f);
+  pass.SetScissorRect(0, 0, task.width, task.height);
   pass.Draw(3);
-  pass.End();
 }
 
-bool ensure_fxaa_task_registered() {
-  if (g_FxaaTaskId != gfx::InvalidEncoderTask) {
+bool ensure_fxaa_draw_registered() {
+  if (g_FxaaDrawTypeId != gfx::InvalidDrawType) {
     return true;
   }
-  g_FxaaTaskId = gfx::register_encoder_task_type(gfx::EncoderTaskDescriptor{
+  g_FxaaDrawTypeId = gfx::register_draw_type(gfx::DrawTypeDescriptor{
       .label = "FXAA",
-      .callback = fxaa_encoder_task_callback,
+      .draw = fxaa_draw_callback,
   });
-  return g_FxaaTaskId != gfx::InvalidEncoderTask;
+  return g_FxaaDrawTypeId != gfx::InvalidDrawType;
 }
 
 } // namespace
 
 void queue_fxaa_pass() noexcept {
-  g_fxaaQueued = false;
-  if (!g_fxaaEnabled.load(std::memory_order_relaxed) || !ensure_fxaa_task_registered()) {
+  if (!g_fxaaEnabled.load(std::memory_order_relaxed) || !ensure_fxaa_draw_registered()) {
     return;
   }
 
@@ -1037,21 +1009,19 @@ void queue_fxaa_pass() noexcept {
     return;
   }
   // resolve_pass()'s pooled view is owned by `resolved`, which goes out of scope at the end of
-  // this function -- long before fxaa_encoder_task_callback() actually runs (it fires later, from
-  // the render worker, once this frame is being encoded). AddRef an extra reference for the
+  // this function -- long before fxaa_draw_callback() actually runs (it fires later, from the
+  // render worker, once this frame's ops reach this point). AddRef an extra reference for the
   // payload to carry across that gap; the callback wraps it with wgpu::TextureView::Acquire(),
   // whose destructor releases exactly that extra reference.
   wgpuTextureViewAddRef(resolved.color.Get());
-  const FxaaTaskPayload payload{
+  const FxaaDrawPayload payload{
       .colorView = resolved.color.Get(),
       .width = resolved.width,
       .height = resolved.height,
   };
-  if (!gfx::push_encoder_task(g_FxaaTaskId, &payload, sizeof(payload))) {
+  if (!gfx::push_custom_draw(g_FxaaDrawTypeId, &payload, sizeof(payload))) {
     wgpuTextureViewRelease(payload.colorView);
-    return;
   }
-  g_fxaaQueued = true;
 }
 
 static wgpu::BackendType to_wgpu_backend(AuroraBackend backend) {

--- a/lib/webgpu/gpu.hpp
+++ b/lib/webgpu/gpu.hpp
@@ -68,14 +68,12 @@ wgpu::BindGroup create_copy_bind_group(const TextureWithSampler& source);
 void set_resampler(AuroraSampler sampler) noexcept;
 AuroraSampler get_resampler() noexcept;
 void set_fxaa_enabled(bool enabled) noexcept;
-// Queues FXAA as an encoder task against the still-open EFB pass; must be called once per frame,
-// after the frame's HUD has been drawn and before gfx::finish() (see aurora_queue_fxaa_pass's doc
-// comment for why). No-op if FXAA is disabled.
+// Injects FXAA as a custom draw directly into the still-open EFB pass; must be called once per
+// frame, before the frame's HUD is drawn and while that pass is still open (see
+// aurora_queue_fxaa_pass's doc comment for why). No-op if FXAA is disabled. Draws in place, so
+// present_source() reflects the antialiased result on its own -- nothing else needs to know FXAA
+// ran.
 void queue_fxaa_pass() noexcept;
-// present_source(), or the FXAA'd copy of it if queue_fxaa_pass() ran successfully this frame.
-// Everything that composites the final displayed frame (RmlUI's backdrop seed, the present blit)
-// should read from this instead of present_source() directly, or it'll see the un-antialiased image.
-const TextureWithSampler& aa_present_source() noexcept;
 Viewport calculate_present_viewport(uint32_t surface_width, uint32_t surface_height, uint32_t content_width,
                                     uint32_t content_height) noexcept;
 const TextureWithSampler& resample_present_source(const wgpu::CommandEncoder& encoder, const Viewport& viewport);

--- a/lib/webgpu/gpu.hpp
+++ b/lib/webgpu/gpu.hpp
@@ -67,6 +67,15 @@ const TextureWithSampler& present_source() noexcept;
 wgpu::BindGroup create_copy_bind_group(const TextureWithSampler& source);
 void set_resampler(AuroraSampler sampler) noexcept;
 AuroraSampler get_resampler() noexcept;
+void set_fxaa_enabled(bool enabled) noexcept;
+// Queues FXAA as an encoder task against the still-open EFB pass; must be called once per frame,
+// after the frame's HUD has been drawn and before gfx::finish() (see aurora_queue_fxaa_pass's doc
+// comment for why). No-op if FXAA is disabled.
+void queue_fxaa_pass() noexcept;
+// present_source(), or the FXAA'd copy of it if queue_fxaa_pass() ran successfully this frame.
+// Everything that composites the final displayed frame (RmlUI's backdrop seed, the present blit)
+// should read from this instead of present_source() directly, or it'll see the un-antialiased image.
+const TextureWithSampler& aa_present_source() noexcept;
 Viewport calculate_present_viewport(uint32_t surface_width, uint32_t surface_height, uint32_t content_width,
                                     uint32_t content_height) noexcept;
 const TextureWithSampler& resample_present_source(const wgpu::CommandEncoder& encoder, const Viewport& viewport);


### PR DESCRIPTION
## Summary
- Adds a live, no-restart FXAA post-process anti-aliasing pass (drawn in-place into the still-open EFB pass so it composites correctly under RmlUI backdrops and before the HUD draws)
- Adds MSAA support to the depth-readback paths (`depth_peek`, `tex_copy_conv`)
- Fixes FXAA blurring the whole frame instead of just smoothing jagged edges: the reduced/console FXAA shader was blending every pixel unconditionally (no local-contrast edge check), so real textures with any diagonal luma delta got softened along with actual geometry silhouettes. Restores the edge-threshold early-out from full FXAA 3.11, gated via `select()` to stay branchless.

## Test plan
- Built and ran on macOS (Metal backend) against a Twilight Princess (GameCube, USA) disc via the Dusklight downstream project
- A/B compared the same in-game frame with Anti-Aliasing set to Off vs FXAA via the live graphics-tuner overlay: geometry silhouette edges (e.g. wooden post outlines) visibly smooth under FXAA, while sign text and other fine detail stay equally sharp in both -- confirming selective edge smoothing rather than a global blur

This is my first PR so AI assistance was used. Feel free to let me know about any mistakes or changes to be made.