### PR TITLE
Fix missing include <cstring>

### DIFF
--- a/lib/internal.hpp
+++ b/lib/internal.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <type_traits>
 #include <vector>
+#include <cstring>
 
 using namespace std::string_view_literals;
 


### PR DESCRIPTION
Compilation failed because cstring was missing, here the error log:

```
[189/1814] Building CXX object extern/aurora/CMakeFiles/aurora_core.dir/lib/system_info.cpp.o
FAILED: [code=1] extern/aurora/CMakeFiles/aurora_core.dir/lib/system_info.cpp.o
/usr/bin/c++ -DAURORA -DAURORA_CACHE_USE_ZSTD -DAURORA_ENABLE_GX -DAURORA_ENABLE_RMLUI -DDAWN_ENABLE_BACKEND_DESKTOP_GL -DDAWN_ENABLE_BACKEND_NULL -DDAWN_ENABLE_BACKEND_OPENGL -DDAWN_ENABLE_BACKEND_OPENGLES -DDAWN_ENABLE_BACKEND_VULKAN -DFMT_SHARED -DIMGUI_ENABLE_FREETYPE -DIMGUI_USER_CONFIG=\"aurora/imgui_config.h\" -DRMLUI_SDL_VERSION_MAJOR=3 -DRMLUI_STATIC_LIB -DTARGET_PC -DTRACY_ON_DEMAND -DWEBGPU_DAWN -I/home/rodney/Git/dusklight/extern/aurora/include -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/xxhash-src/cmake_unofficial/.. -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/imgui-src -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/rmlui-src/Include -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/rmlui-src/Backends -isystem /home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/tracy-src/public -isystem /home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/dawn_prebuilt-src/include -O2 -g -DNDEBUG -std=gnu++20 -fPIC -fdiagnostics-color=always -MD -MT extern/aurora/CMakeFiles/aurora_core.dir/lib/system_info.cpp.o -MF extern/aurora/CMakeFiles/aurora_core.dir/lib/system_info.cpp.o.d -o extern/aurora/CMakeFiles/aurora_core.dir/lib/system_info.cpp.o -c /home/rodney/Git/dusklight/extern/aurora/lib/system_info.cpp
In file included from /home/rodney/Git/dusklight/extern/aurora/lib/system_info.cpp:2:
/home/rodney/Git/dusklight/extern/aurora/lib/internal.hpp: In function ‘T unaligned_load(const void*)’:
/home/rodney/Git/dusklight/extern/aurora/lib/internal.hpp:86:8: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’? [-Wtemplate-body]
   86 |   std::memcpy(&value, ptr, sizeof(value));
      |        ^~~~~~
      |        wmemcpy
/home/rodney/Git/dusklight/extern/aurora/lib/internal.hpp: In member function ‘aurora::ByteBuffer aurora::ByteBuffer::clone() const’:
/home/rodney/Git/dusklight/extern/aurora/lib/internal.hpp:315:10: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’?
  315 |     std::memcpy(clone.data(), m_data, m_length);
      |          ^~~~~~
      |          wmemcpy
[196/1814] Building CXX object extern/aurora/CMakeFiles/aurora_core.dir/lib/rmlui/WebGPURenderInterface.cpp.o
FAILED: [code=1] extern/aurora/CMakeFiles/aurora_core.dir/lib/rmlui/WebGPURenderInterface.cpp.o
/usr/bin/c++ -DAURORA -DAURORA_CACHE_USE_ZSTD -DAURORA_ENABLE_GX -DAURORA_ENABLE_RMLUI -DDAWN_ENABLE_BACKEND_DESKTOP_GL -DDAWN_ENABLE_BACKEND_NULL -DDAWN_ENABLE_BACKEND_OPENGL -DDAWN_ENABLE_BACKEND_OPENGLES -DDAWN_ENABLE_BACKEND_VULKAN -DFMT_SHARED -DIMGUI_ENABLE_FREETYPE -DIMGUI_USER_CONFIG=\"aurora/imgui_config.h\" -DRMLUI_SDL_VERSION_MAJOR=3 -DRMLUI_STATIC_LIB -DTARGET_PC -DTRACY_ON_DEMAND -DWEBGPU_DAWN -I/home/rodney/Git/dusklight/extern/aurora/include -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/xxhash-src/cmake_unofficial/.. -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/imgui-src -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/rmlui-src/Include -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/rmlui-src/Backends -isystem /home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/tracy-src/public -isystem /home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/dawn_prebuilt-src/include -O2 -g -DNDEBUG -std=gnu++20 -fPIC -fdiagnostics-color=always -MD -MT extern/aurora/CMakeFiles/aurora_core.dir/lib/rmlui/WebGPURenderInterface.cpp.o -MF extern/aurora/CMakeFiles/aurora_core.dir/lib/rmlui/WebGPURenderInterface.cpp.o.d -o extern/aurora/CMakeFiles/aurora_core.dir/lib/rmlui/WebGPURenderInterface.cpp.o -c /home/rodney/Git/dusklight/extern/aurora/lib/rmlui/WebGPURenderInterface.cpp
In file included from /home/rodney/Git/dusklight/extern/aurora/lib/rmlui/../gfx/types.hpp:4,
                 from /home/rodney/Git/dusklight/extern/aurora/lib/rmlui/../gfx/clear.hpp:5,
                 from /home/rodney/Git/dusklight/extern/aurora/lib/rmlui/WebGPURenderInterface.hpp:7,
                 from /home/rodney/Git/dusklight/extern/aurora/lib/rmlui/WebGPURenderInterface.cpp:1:
/home/rodney/Git/dusklight/extern/aurora/lib/rmlui/../gfx/../internal.hpp: In function ‘T unaligned_load(const void*)’:
/home/rodney/Git/dusklight/extern/aurora/lib/rmlui/../gfx/../internal.hpp:86:8: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’? [-Wtemplate-body]
   86 |   std::memcpy(&value, ptr, sizeof(value));
      |        ^~~~~~
      |        wmemcpy
/home/rodney/Git/dusklight/extern/aurora/lib/rmlui/../gfx/../internal.hpp: In member function ‘aurora::ByteBuffer aurora::ByteBuffer::clone() const’:
/home/rodney/Git/dusklight/extern/aurora/lib/rmlui/../gfx/../internal.hpp:315:10: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’?
  315 |     std::memcpy(clone.data(), m_data, m_length);
      |          ^~~~~~
      |          wmemcpy
[200/1814] Building CXX object extern/aurora/CMakeFiles/aurora_core.dir/lib/aurora.cpp.o
FAILED: [code=1] extern/aurora/CMakeFiles/aurora_core.dir/lib/aurora.cpp.o
/usr/bin/c++ -DAURORA -DAURORA_CACHE_USE_ZSTD -DAURORA_ENABLE_GX -DAURORA_ENABLE_RMLUI -DDAWN_ENABLE_BACKEND_DESKTOP_GL -DDAWN_ENABLE_BACKEND_NULL -DDAWN_ENABLE_BACKEND_OPENGL -DDAWN_ENABLE_BACKEND_OPENGLES -DDAWN_ENABLE_BACKEND_VULKAN -DFMT_SHARED -DIMGUI_ENABLE_FREETYPE -DIMGUI_USER_CONFIG=\"aurora/imgui_config.h\" -DRMLUI_SDL_VERSION_MAJOR=3 -DRMLUI_STATIC_LIB -DTARGET_PC -DTRACY_ON_DEMAND -DWEBGPU_DAWN -I/home/rodney/Git/dusklight/extern/aurora/include -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/xxhash-src/cmake_unofficial/.. -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/imgui-src -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/rmlui-src/Include -I/home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/rmlui-src/Backends -isystem /home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/tracy-src/public -isystem /home/rodney/Git/dusklight/build/linux-default-relwithdebinfo/_deps/dawn_prebuilt-src/include -O2 -g -DNDEBUG -std=gnu++20 -fPIC -fdiagnostics-color=always -MD -MT extern/aurora/CMakeFiles/aurora_core.dir/lib/aurora.cpp.o -MF extern/aurora/CMakeFiles/aurora_core.dir/lib/aurora.cpp.o.d -o extern/aurora/CMakeFiles/aurora_core.dir/lib/aurora.cpp.o -c /home/rodney/Git/dusklight/extern/aurora/lib/aurora.cpp
In file included from /home/rodney/Git/dusklight/extern/aurora/lib/gfx/types.hpp:4,
                 from /home/rodney/Git/dusklight/extern/aurora/lib/gfx/resources.hpp:3,
                 from /home/rodney/Git/dusklight/extern/aurora/lib/aurora.cpp:5:
/home/rodney/Git/dusklight/extern/aurora/lib/gfx/../internal.hpp: In function ‘T unaligned_load(const void*)’:
/home/rodney/Git/dusklight/extern/aurora/lib/gfx/../internal.hpp:86:8: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’? [-Wtemplate-body]
   86 |   std::memcpy(&value, ptr, sizeof(value));
      |        ^~~~~~
      |        wmemcpy
/home/rodney/Git/dusklight/extern/aurora/lib/gfx/../internal.hpp: In member function ‘aurora::ByteBuffer aurora::ByteBuffer::clone() const’:
/home/rodney/Git/dusklight/extern/aurora/lib/gfx/../internal.hpp:315:10: error: ‘memcpy’ is not a member of ‘std’; did you mean ‘wmemcpy’?
  315 |     std::memcpy(clone.data(), m_data, m_length);
      |          ^~~~~~
      |          wmemcpy
[202/1814] Building CXX object extern/aurora/CMakeFiles/aurora_core.dir/lib/webgpu/gpu.cpp.o
ninja: build stopped: subcommand failed.
```