### PR TITLE
gfx: add an optional scene normal attachment

### DIFF
--- a/include/aurora/aurora.h
+++ b/include/aurora/aurora.h
@@ -93,6 +93,13 @@ typedef struct {
   bool pauseOnFocusLost;
   bool allowTextureDumps;
   bool allowCpuAdapter;
+
+  /*
+   * Adds a scene color attachment holding the view-space vertex normal of every depth-writing draw.
+   * Requires core features and is silently ignored without them, so consumers should look for
+   * ColorAttachmentSemantic::Normal in the scene layout rather than assume it is present.
+   */
+  bool normalBuffer;
   int32_t windowPosX;
   int32_t windowPosY;
   uint32_t windowWidth;

--- a/include/aurora/gfx.hpp
+++ b/include/aurora/gfx.hpp
@@ -14,6 +14,9 @@ inline constexpr uint32_t SceneColorAttachmentIndex = 0;
 
 enum class ColorAttachmentSemantic : uint8_t {
   SceneColor,
+  /// View-space vertex normal of whichever draw established the depth at each pixel, encoded xyz * 0.5 + 0.5, with
+  /// alpha 1 where it is usable and 0 otherwise. Its coverage is the depth buffer's, and the sign is the game's:
+  /// consumers must not reorient it against the view.
   Normal,
   Auxiliary,
 };
@@ -144,11 +147,13 @@ Range push_storage(const uint8_t* data, size_t length);
 struct ResolveDesc {
   bool color = true;
   bool depth = false;
+  bool normal = false;
 };
 
 struct ResolvedTargets {
-  wgpu::TextureView color; // single-sample snapshot; null if not requested
-  wgpu::TextureView depth; // single-sample R32Float depth snapshot; null if not requested
+  wgpu::TextureView color;  // single-sample snapshot; null if not requested
+  wgpu::TextureView depth;  // single-sample R32Float depth snapshot; null if not requested
+  wgpu::TextureView normal; // single-sample snapshot of the Normal attachment; null if not requested
   wgpu::TextureFormat colorFormat = wgpu::TextureFormat::Undefined;
   uint32_t width = 0;
   uint32_t height = 0;

--- a/lib/gfx/encoding.cpp
+++ b/lib/gfx/encoding.cpp
@@ -314,6 +314,21 @@ void render(wgpu::CommandEncoder& cmd, FramePacket& frame, RenderPass& passInfo,
   if (passInfo.snapshotDepthDst) {
     tex_copy_conv::snapshot_depth(cmd, passInfo.copySourceDepthView, passInfo.msaaSamples, passInfo.snapshotDepthDst);
   }
+  if (passInfo.snapshotNormalDst) {
+    const webgpu::gpu_prof::Zone zone{cmd, "Normal snapshot"};
+    const wgpu::TexelCopyTextureInfo src{
+        .texture = passInfo.copySourceNormalTexture,
+    };
+    const wgpu::TexelCopyTextureInfo dst{
+        .texture = passInfo.snapshotNormalDst,
+    };
+    const wgpu::Extent3D size{
+        .width = passInfo.colorAttachments[SceneColorAttachmentIndex].size.width,
+        .height = passInfo.colorAttachments[SceneColorAttachmentIndex].size.height,
+        .depthOrArrayLayers = 1,
+    };
+    cmd.CopyTextureToTexture(&src, &dst, &size);
+  }
 }
 
 constexpr uint64_t VertexStagingOffset = 0;

--- a/lib/gfx/frame.cpp
+++ b/lib/gfx/frame.cpp
@@ -293,6 +293,14 @@ RenderTargetLayout scene_render_target_layout() noexcept {
       .depthStencilFormat = webgpu::g_graphicsConfig.depthFormat,
       .sampleCount = webgpu::g_graphicsConfig.msaaSamples,
   };
+  if (webgpu::g_graphicsConfig.normalBuffer) {
+    layout.colorAttachments[layout.colorAttachmentCount++] = {
+        .semantic = ColorAttachmentSemantic::Normal,
+        .format = webgpu::g_normalBuffer.format,
+        .width = webgpu::g_normalBuffer.size.width,
+        .height = webgpu::g_normalBuffer.size.height,
+    };
+  }
   finalize_render_target_layout(layout);
   return layout;
 }

--- a/lib/gfx/frame_packet.hpp
+++ b/lib/gfx/frame_packet.hpp
@@ -82,6 +82,7 @@ struct RenderPass {
   wgpu::Texture copySourceTexture;
   wgpu::TextureView copySourceView;
   wgpu::TextureView copySourceDepthView;
+  wgpu::Texture copySourceNormalTexture;
   uint32_t msaaSamples = 1;
 
   TextureHandle resolveTarget;
@@ -90,6 +91,7 @@ struct RenderPass {
   Range resolveUniformRange;
   wgpu::Texture snapshotColorDst;
   wgpu::TextureView snapshotDepthDst;
+  wgpu::Texture snapshotNormalDst;
   float clearDepthValue = 1.f;
   wgpu::LoadOp depthLoadOp = wgpu::LoadOp::Undefined;
   wgpu::StoreOp depthStoreOp = wgpu::StoreOp::Store;
@@ -107,7 +109,7 @@ struct RenderPass {
   std::vector<tex_palette_conv::ConvRequest> paletteConvs;
 
   RenderTargetLayout target_layout() const noexcept;
-  bool has_consumer() const { return resolveTarget || snapshotColorDst || snapshotDepthDst; }
+  bool has_consumer() const { return resolveTarget || snapshotColorDst || snapshotDepthDst || snapshotNormalDst; }
   bool has_content() const {
     if (hasDraws || clearDepth) {
       return true;

--- a/lib/gfx/recording.cpp
+++ b/lib/gfx/recording.cpp
@@ -91,7 +91,13 @@ void set_efb_targets(RenderPass& pass) {
     auto& color = pass.colorAttachments[i];
     color.semantic = layout.colorAttachments[i].semantic;
     color.format = layout.colorAttachments[i].format;
-    AURORA_ASSERT(false, "Scene render-target attachment {} has no backing texture", i);
+    if (color.semantic == ColorAttachmentSemantic::Normal) {
+      color.size = webgpu::g_normalBuffer.size;
+      color.view = webgpu::g_normalBuffer.view;
+      color.resolveView = layout.sampleCount > 1 ? webgpu::g_normalBufferResolved.view : nullptr;
+    } else {
+      AURORA_ASSERT(false, "Scene render-target attachment {} has no backing texture", i);
+    }
   }
   pass.depthStencilView = webgpu::g_depthBuffer.view;
   pass.depthStencilFormat = layout.depthStencilFormat;
@@ -100,6 +106,10 @@ void set_efb_targets(RenderPass& pass) {
   pass.copySourceView =
       webgpu::g_graphicsConfig.msaaSamples > 1 ? webgpu::g_frameBufferResolved.view : webgpu::g_frameBuffer.view;
   pass.copySourceDepthView = webgpu::g_depthBuffer.view;
+  if (webgpu::g_graphicsConfig.normalBuffer) {
+    pass.copySourceNormalTexture =
+        layout.sampleCount > 1 ? webgpu::g_normalBufferResolved.texture : webgpu::g_normalBuffer.texture;
+  }
   pass.msaaSamples = layout.sampleCount;
   pass.hasDepth = true;
   pass.hasStencil = false;
@@ -139,6 +149,7 @@ absl::flat_hash_map<OffscreenCacheKey, OffscreenCacheEntry> g_offscreenCache;
 struct PassSnapshotEntry {
   webgpu::TextureWithSampler color;
   webgpu::TextureWithSampler depth; // R32Float raw depth
+  webgpu::TextureWithSampler normal;
 };
 struct PassSnapshotPool {
   std::vector<PassSnapshotEntry> entries;
@@ -146,7 +157,8 @@ struct PassSnapshotPool {
 };
 std::array<PassSnapshotPool, FrameSlotCount> g_passSnapshotPools;
 
-PassSnapshotEntry& acquire_pass_snapshot(uint32_t width, uint32_t height, bool wantColor, bool wantDepth) {
+PassSnapshotEntry& acquire_pass_snapshot(uint32_t width, uint32_t height, bool wantColor, bool wantDepth,
+                                         bool wantNormal) {
   auto& pool = g_passSnapshotPools[g_recorder.frameSlot];
   if (pool.used == pool.entries.size()) {
     pool.entries.emplace_back();
@@ -191,6 +203,25 @@ PassSnapshotEntry& acquire_pass_snapshot(uint32_t width, uint32_t height, bool w
         .view = std::move(view),
         .size = size,
         .format = wgpu::TextureFormat::R32Float,
+    };
+  }
+  if (wantNormal && (!entry.normal.texture || entry.normal.size.width != width || entry.normal.size.height != height)) {
+    const wgpu::TextureDescriptor desc{
+        .label = "Pass Snapshot Normal",
+        .usage = wgpu::TextureUsage::CopyDst | wgpu::TextureUsage::TextureBinding,
+        .dimension = wgpu::TextureDimension::e2D,
+        .size = size,
+        .format = webgpu::NormalBufferFormat,
+        .mipLevelCount = 1,
+        .sampleCount = 1,
+    };
+    auto texture = webgpu::g_device.CreateTexture(&desc);
+    auto view = texture.CreateView();
+    entry.normal = webgpu::TextureWithSampler{
+        .texture = std::move(texture),
+        .view = std::move(view),
+        .size = size,
+        .format = webgpu::NormalBufferFormat,
     };
   }
   return entry;
@@ -402,6 +433,7 @@ void resume_efb_pass_loading(const RenderPass& prevPass) {
       .copySourceTexture = prevPass.copySourceTexture,
       .copySourceView = prevPass.copySourceView,
       .copySourceDepthView = prevPass.copySourceDepthView,
+      .copySourceNormalTexture = prevPass.copySourceNormalTexture,
       .msaaSamples = prevPass.msaaSamples,
       .clearDepth = false,
       .hasDepth = prevPass.hasDepth,
@@ -818,6 +850,7 @@ void resolve_pass_into(TextureHandle texture, ClipRect rect, bool clearColor, bo
       .copySourceTexture = prevPass.copySourceTexture,
       .copySourceView = prevPass.copySourceView,
       .copySourceDepthView = prevPass.copySourceDepthView,
+      .copySourceNormalTexture = prevPass.copySourceNormalTexture,
       .msaaSamples = msaaSamples,
       .clearDepthValue = clearDepthValue,
       .clearDepth = clearDepth,
@@ -828,7 +861,8 @@ void resolve_pass_into(TextureHandle texture, ClipRect rect, bool clearColor, bo
   for (uint32_t i = 0; i < newPass.colorAttachmentCount; ++i) {
     auto& color = newPass.colorAttachments[i];
     color.loadOp = wgpu::LoadOp::Undefined;
-    color.clear = false;
+    // A normal belongs to whichever draw owns the depth at that pixel, so it resets with depth, not with color.
+    color.clear = color.semantic == ColorAttachmentSemantic::Normal && clearDepth;
   }
   if (fullColorClear) {
     auto& sceneColor = newPass.colorAttachments[SceneColorAttachmentIndex];
@@ -869,6 +903,17 @@ bool is_offscreen() noexcept { return g_recorder.inOffscreen; }
 uint32_t get_sample_count() noexcept {
   CHECK(g_recorder.currentRenderPass != UINT32_MAX, "get_sample_count called outside of a frame");
   return current_render_passes()[g_recorder.currentRenderPass].msaaSamples;
+}
+
+bool has_normal_attachment() noexcept {
+  CHECK(g_recorder.currentRenderPass != UINT32_MAX, "has_normal_attachment called outside of a frame");
+  const auto& pass = current_render_passes()[g_recorder.currentRenderPass];
+  for (uint32_t i = 0; i < pass.colorAttachmentCount; ++i) {
+    if (pass.colorAttachments[i].semantic == ColorAttachmentSemantic::Normal) {
+      return true;
+    }
+  }
+  return false;
 }
 
 RenderTargetLayout get_render_target_layout() noexcept {
@@ -976,9 +1021,11 @@ bool resolve_pass(const ResolveDesc& desc, ResolvedTargets& out) {
   auto& prevPass = current_render_passes()[g_recorder.currentRenderPass];
   const uint32_t width = prevPass.colorAttachments[SceneColorAttachmentIndex].size.width;
   const uint32_t height = prevPass.colorAttachments[SceneColorAttachmentIndex].size.height;
+  // Offscreen passes carry no normal attachment.
+  const bool wantNormal = desc.normal && prevPass.copySourceNormalTexture;
   // Requesting no snapshots is a plain pass break (or offscreen close, discarding its output).
-  if (desc.color || wantDepth) {
-    auto& entry = acquire_pass_snapshot(width, height, desc.color, wantDepth);
+  if (desc.color || wantDepth || wantNormal) {
+    auto& entry = acquire_pass_snapshot(width, height, desc.color, wantDepth, wantNormal);
     if (desc.color) {
       prevPass.snapshotColorDst = entry.color.texture;
       out.color = entry.color.view;
@@ -987,6 +1034,10 @@ bool resolve_pass(const ResolveDesc& desc, ResolvedTargets& out) {
     if (wantDepth) {
       prevPass.snapshotDepthDst = entry.depth.view;
       out.depth = entry.depth.view;
+    }
+    if (wantNormal) {
+      prevPass.snapshotNormalDst = entry.normal.texture;
+      out.normal = entry.normal.view;
     }
   }
   out.width = width;

--- a/lib/gfx/recording.hpp
+++ b/lib/gfx/recording.hpp
@@ -57,6 +57,7 @@ void queue_texture_copy(wgpu::TexelCopyTextureInfo src, wgpu::TexelCopyTextureIn
 void begin_offscreen(uint32_t width, uint32_t height);
 void end_offscreen();
 uint32_t get_sample_count() noexcept;
+bool has_normal_attachment() noexcept;
 RenderTargetLayout get_render_target_layout() noexcept;
 void clear_caches() noexcept;
 

--- a/lib/gx/gx.cpp
+++ b/lib/gx/gx.cpp
@@ -319,9 +319,10 @@ wgpu::RenderPipeline build_pipeline(const PipelineConfig& config, ArrayRef<wgpu:
   const float depthBias = (UseReversedZ ? -1.0f : 1.0f) * std::bit_cast<float>(config.polygonOffsetBits);
   const float depthBiasSlopeScale = (UseReversedZ ? -1.0f : 1.0f) * std::bit_cast<float>(config.polygonOffsetScaleBits);
   const float depthBiasClamp = webgpu::g_hasCoreFeatures ? std::bit_cast<float>(config.polygonOffsetClampBits) : 0.0f;
+  const bool writesDepth = config.depthCompare && config.depthUpdate;
   const wgpu::DepthStencilState depthStencil{
       .format = g_graphicsConfig.depthFormat,
-      .depthWriteEnabled = config.depthCompare && config.depthUpdate,
+      .depthWriteEnabled = writesDepth,
       .depthCompare = config.depthCompare ? to_compare_function(config.depthFunc) : wgpu::CompareFunction::Always,
       .depthBias = round_away_from_zero<int32_t>(depthBias),
       .depthBiasSlopeScale = depthBiasSlopeScale,
@@ -329,15 +330,23 @@ wgpu::RenderPipeline build_pipeline(const PipelineConfig& config, ArrayRef<wgpu:
   };
   const auto blendState =
       to_blend_state(config.blendMode, config.blendFacSrc, config.blendFacDst, config.blendOp, config.dstAlpha);
-  const std::array colorTargets{wgpu::ColorTargetState{
-      .format = g_graphicsConfig.surfaceConfiguration.format,
-      .blend = &blendState,
-      .writeMask = to_write_mask(config.colorUpdate, config.alphaUpdate),
-  }};
+  const std::array colorTargets{
+      wgpu::ColorTargetState{
+          .format = g_graphicsConfig.surfaceConfiguration.format,
+          .blend = &blendState,
+          .writeMask = to_write_mask(config.colorUpdate, config.alphaUpdate),
+      },
+      // Only the draw that establishes the depth at a pixel owns its normal; draws that merely blend over the scene
+      // leave it alone.
+      wgpu::ColorTargetState{
+          .format = webgpu::NormalBufferFormat,
+          .writeMask = writesDepth ? wgpu::ColorWriteMask::All : wgpu::ColorWriteMask::None,
+      },
+  };
   const wgpu::FragmentState fragmentState{
       .module = shader,
       .entryPoint = "fs_main",
-      .targetCount = colorTargets.size(),
+      .targetCount = config.shaderConfig.normalTarget ? 2u : 1u,
       .targets = colorTargets.data(),
   };
   const wgpu::RenderPipelineDescriptor descriptor{
@@ -368,6 +377,7 @@ void populate_pipeline_config(PipelineConfig& config, GXPrimitive primitive, GXV
   config.shaderConfig = {};
   config.shaderConfig.fogType = g_gxState.fog.type;
   config.shaderConfig.fogRangeEnabled = g_gxState.fog.rangeEnabled;
+  config.shaderConfig.normalTarget = gfx::has_normal_attachment();
   u8 vtxOffset = 0;
   for (int i = GX_VA_PNMTXIDX; i <= GX_VA_TEX7; ++i) {
     const auto attr = static_cast<GXAttr>(i);

--- a/lib/gx/gx.hpp
+++ b/lib/gx/gx.hpp
@@ -491,7 +491,8 @@ struct ShaderConfig {
   u8 vtxStride = 0;
   u8 lineMode : 2 = 0; // 1 = GX_LINES, 2 = GX_LINESTRIP, 3 = GX_POINTS
   u8 fogRangeEnabled : 1 = false;
-  u8 pad1 : 5 = 0;
+  u8 normalTarget : 1 = false;
+  u8 pad1 : 4 = 0;
   u8 pad2 = 0;
   std::array<AttrConfig, MaxVtxAttr> attrs;
   std::array<TevSwap, MaxTevSwap> tevSwapTable;

--- a/lib/gx/shader.cpp
+++ b/lib/gx/shader.cpp
@@ -1064,6 +1064,12 @@ std::string build_shader_source(const ShaderConfig& config) noexcept {
     vtxOutAttrs += fmt::format("\n    @location({}) nrm: vec3f,", vtxOutIdx++);
     vtxXfrAttrsPre += "\n    out.nrm = mv_nrm;";
   }
+  const bool hasAuthoredNormal = config.attrs[GX_VA_NRM].attrType != GX_NONE;
+  const bool emitNormalTarget = config.normalTarget && hasAuthoredNormal;
+  if (emitNormalTarget && !(UsePerPixelLighting && info.lightingEnabled)) {
+    vtxOutAttrs += fmt::format("\n    @location({}) mv_nrm: vec3f,", vtxOutIdx++);
+    vtxXfrAttrsPre += "\n    out.mv_nrm = mv_nrm;";
+  }
 
   uniBufAttrs += "\n    proj: mat4x4f,";
   uniBufAttrs += fmt::format("\n    postex_mtx: array<mat3x4f, {}>,", MaxPnMtx + MaxTexMtx);
@@ -1628,6 +1634,30 @@ std::string build_shader_source(const ShaderConfig& config) noexcept {
     fragmentFn += "\n    prev = vec4f(in.nrm, prev.a);";
   }
 
+  std::string fragmentOutput;
+  std::string_view fragmentOutputType = "@location(0) vec4f"sv;
+  std::string fragmentReturn = "\n    return prev;"s;
+  if (config.normalTarget) {
+    fragmentOutput =
+        "\nstruct FragmentOutput {\n"
+        "    @location(0) color: vec4f,\n"
+        "    @location(1) normal: vec4f,\n"
+        "};\n";
+    fragmentOutputType = "FragmentOutput"sv;
+    fragmentReturn = "\n    var out: FragmentOutput;\n    out.color = prev;";
+    if (emitNormalTarget) {
+      // Interpolation denormalizes, and can cancel opposed vertex normals outright; alpha reports whether what came
+      // out is usable, so a consumer never normalizes a zero vector.
+      fragmentReturn +=
+          "\n    let nrm_len_sq = dot(in.mv_nrm, in.mv_nrm);"
+          "\n    let unit_nrm = select(vec3f(0.0), normalize(in.mv_nrm), nrm_len_sq > 1e-10);"
+          "\n    out.normal = vec4f(unit_nrm * 0.5 + 0.5, select(0.0, 1.0, nrm_len_sq > 1e-10));";
+    } else {
+      fragmentReturn += "\n    out.normal = vec4f(0.5, 0.5, 0.5, 0.0);";
+    }
+    fragmentReturn += "\n    return out;";
+  }
+
   const auto shaderSource = fmt::format(R"""(
 fn bswap32(v: u32, le: bool) -> u32 {{
   if (le) {{
@@ -1991,13 +2021,14 @@ fn vs_main(
     return out;
 }}
 
+{9}
 @fragment
-fn fs_main(in: VertexOutput) -> @location(0) vec4f {{{6}{5}
-    return prev;
+fn fs_main(in: VertexOutput) -> {10} {{{6}{5}{11}
 }}
 )""",
                                         uniBufAttrs, texBindings, vtxOutAttrs, vtxInAttrs, vtxXfrAttrs, fragmentFn,
-                                        fragmentFnPre, vtxXfrAttrsPre, uniformPre);
+                                        fragmentFnPre, vtxXfrAttrsPre, uniformPre, fragmentOutput, fragmentOutputType,
+                                        fragmentReturn);
   if (EnableDebugPrints) {
     Log.info("Generated shader (hash {:x}): {}", hash, shaderSource);
   }

--- a/lib/webgpu/gpu.cpp
+++ b/lib/webgpu/gpu.cpp
@@ -48,6 +48,8 @@ GraphicsConfig g_graphicsConfig;
 TextureWithSampler g_frameBuffer;
 TextureWithSampler g_frameBufferResolved;
 TextureWithSampler g_depthBuffer;
+TextureWithSampler g_normalBuffer;
+TextureWithSampler g_normalBufferResolved;
 
 // EFB -> XFB copy pipeline
 static wgpu::BindGroupLayout g_CopyBindGroupLayout;
@@ -404,6 +406,37 @@ static TextureWithSampler create_depth_texture(uint32_t width, uint32_t height) 
       .size = size,
       .format = format,
       .sampler = std::move(sampler),
+  };
+}
+
+static TextureWithSampler create_normal_texture(uint32_t width, uint32_t height, bool multisampled) {
+  const wgpu::Extent3D size{
+      .width = width,
+      .height = height,
+      .depthOrArrayLayers = 1,
+  };
+  const wgpu::TextureDescriptor textureDescriptor{
+      .label = "Normal texture",
+      .usage = wgpu::TextureUsage::RenderAttachment | wgpu::TextureUsage::TextureBinding | wgpu::TextureUsage::CopySrc,
+      .dimension = wgpu::TextureDimension::e2D,
+      .size = size,
+      .format = NormalBufferFormat,
+      .mipLevelCount = 1,
+      .sampleCount = multisampled ? g_graphicsConfig.msaaSamples : 1,
+  };
+  auto texture = g_device.CreateTexture(&textureDescriptor);
+
+  const wgpu::TextureViewDescriptor viewDescriptor{
+      .label = "Normal texture view",
+      .dimension = wgpu::TextureViewDimension::e2D,
+  };
+  auto view = texture.CreateView(&viewDescriptor);
+
+  return {
+      .texture = std::move(texture),
+      .view = std::move(view),
+      .size = size,
+      .format = NormalBufferFormat,
   };
 }
 
@@ -1029,6 +1062,9 @@ bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
   Log.info("Using surface format {}, present mode {}", magic_enum::enum_name(surfaceFormat),
            magic_enum::enum_name(presentMode));
   const auto size = window::get_window_size();
+  // Compatibility mode requires every color target of a pipeline to share one write mask and blend state, which the
+  // normal attachment cannot do: it is unblended and written only by depth-writing draws.
+  const bool normalBuffer = g_config.normalBuffer && g_hasCoreFeatures;
   g_graphicsConfig = GraphicsConfig{
       .surfaceConfiguration =
           wgpu::SurfaceConfiguration{
@@ -1041,6 +1077,7 @@ bool initialize(AuroraBackend auroraBackend, bool allowCpu) {
       .depthFormat = wgpu::TextureFormat::Depth32Float,
       .msaaSamples = g_config.msaa,
       .textureAnisotropy = g_config.maxTextureAnisotropy,
+      .normalBuffer = normalBuffer,
   };
   create_copy_pipeline();
   create_resample_pipeline();
@@ -1107,6 +1144,12 @@ static void resize_swapchain_internal(uint32_t width, uint32_t height, uint32_t 
   g_frameBuffer = create_render_texture(width, height, true);
   g_frameBufferResolved = create_render_texture(width, height, false);
   g_depthBuffer = create_depth_texture(width, height);
+  if (g_graphicsConfig.normalBuffer) {
+    g_normalBuffer = create_normal_texture(width, height, true);
+    if (g_graphicsConfig.msaaSamples > 1) {
+      g_normalBufferResolved = create_normal_texture(width, height, false);
+    }
+  }
   g_CopyBindGroup = create_copy_bind_group(present_source());
 }
 

--- a/lib/webgpu/gpu.hpp
+++ b/lib/webgpu/gpu.hpp
@@ -11,11 +11,16 @@
 struct SDL_Window;
 
 namespace aurora::webgpu {
+// Ten bits per axis keeps low-curvature surfaces free of the banding an 8-bit encoding produces, for the same four
+// bytes; the remaining two carry the validity flag.
+inline constexpr wgpu::TextureFormat NormalBufferFormat = wgpu::TextureFormat::RGB10A2Unorm;
+
 struct GraphicsConfig {
   wgpu::SurfaceConfiguration surfaceConfiguration;
   wgpu::TextureFormat depthFormat;
   uint32_t msaaSamples;
   uint16_t textureAnisotropy;
+  bool normalBuffer;
 };
 struct TextureWithSampler {
   wgpu::Texture texture;
@@ -47,6 +52,8 @@ extern GraphicsConfig g_graphicsConfig;
 extern TextureWithSampler g_frameBuffer;
 extern TextureWithSampler g_frameBufferResolved;
 extern TextureWithSampler g_depthBuffer;
+extern TextureWithSampler g_normalBuffer;
+extern TextureWithSampler g_normalBufferResolved;
 extern wgpu::RenderPipeline g_CopyPipeline;
 extern wgpu::RenderPipeline g_CopyPremultipliedAlphaPipeline;
 extern wgpu::BindGroup g_CopyBindGroup;

--- a/tests/gfx_recording_test.cpp
+++ b/tests/gfx_recording_test.cpp
@@ -166,5 +166,66 @@ TEST_F(GfxRecordingTest, FinalizedPassesAreSealedOrDeliberatelyDiscarded) {
   recordingActive = false;
 }
 
+class GfxNormalAttachmentTest : public GfxRecordingTest {
+protected:
+  void SetUp() override {
+    webgpu::g_graphicsConfig.normalBuffer = true;
+    webgpu::g_normalBuffer.size = {640, 480, 1};
+    webgpu::g_normalBuffer.format = webgpu::NormalBufferFormat;
+    GfxRecordingTest::SetUp();
+  }
+
+  void TearDown() override {
+    GfxRecordingTest::TearDown();
+    webgpu::g_graphicsConfig.normalBuffer = false;
+    webgpu::g_normalBuffer = {};
+  }
+
+  void resolve_efb(bool clearColor, bool clearAlpha, bool clearDepth) {
+    const auto size = frame.renderPasses.back().colorAttachments[SceneColorAttachmentIndex].size;
+    auto target = std::make_shared<TextureRef>(wgpu::Texture{}, wgpu::TextureView{}, wgpu::TextureView{}, size,
+                                               ColorFormat, 1, GX_TF_RGBA8);
+    resolve_pass_into(std::move(target), {0, 0, static_cast<int32_t>(size.width), static_cast<int32_t>(size.height)},
+                      clearColor, clearAlpha, clearDepth, {}, 1.f);
+  }
+};
+
+TEST_F(GfxNormalAttachmentTest, EfbPassCarriesNormalAttachment) {
+  ASSERT_FALSE(frame.renderPasses.empty());
+  const auto layout = frame.renderPasses.front().target_layout();
+
+  ASSERT_EQ(layout.colorAttachmentCount, 2u);
+  EXPECT_EQ(layout.colorAttachments[1].semantic, ColorAttachmentSemantic::Normal);
+  EXPECT_EQ(layout.colorAttachments[1].format, webgpu::NormalBufferFormat);
+  EXPECT_TRUE(has_normal_attachment());
+}
+
+TEST_F(GfxNormalAttachmentTest, OffscreenPassesOmitTheNormalAttachment) {
+  seed(320, 180);
+  begin_offscreen(320, 180);
+  EXPECT_EQ(frame.renderPasses.back().colorAttachmentCount, 1u);
+  EXPECT_FALSE(has_normal_attachment());
+
+  end_offscreen();
+
+  EXPECT_TRUE(has_normal_attachment());
+}
+
+TEST_F(GfxNormalAttachmentTest, NormalAttachmentClearsWithDepthNotColor) {
+  resolve_efb(true, true, false);
+  {
+    const auto& pass = frame.renderPasses.back();
+    EXPECT_TRUE(pass.colorAttachments[SceneColorAttachmentIndex].clear);
+    EXPECT_FALSE(pass.colorAttachments[1].clear);
+  }
+
+  resolve_efb(false, false, true);
+  {
+    const auto& pass = frame.renderPasses.back();
+    EXPECT_FALSE(pass.colorAttachments[SceneColorAttachmentIndex].clear);
+    EXPECT_TRUE(pass.colorAttachments[1].clear);
+  }
+}
+
 } // namespace
 } // namespace aurora::gfx

--- a/tests/gx_test_stubs.cpp
+++ b/tests/gx_test_stubs.cpp
@@ -132,6 +132,7 @@ Vec2<uint32_t> get_render_target_size() noexcept { return {640, 480}; }
 void set_viewport(const Viewport& viewport) noexcept {}
 void set_scissor(uint32_t x, uint32_t y, uint32_t w, uint32_t h) noexcept {}
 uint32_t get_sample_count() noexcept { return 1; }
+bool has_normal_attachment() noexcept { return false; }
 RenderTargetLayout get_render_target_layout() noexcept {
   return {
       .colorAttachmentCount = 1,


### PR DESCRIPTION
Encounter recently did a refactor which reorganized how render targets work in Aurora, making additional scene pass attachments possible. A normals entry exists but nothing actually utilizes it yet. With some input from Encounter, I directed a coding agent to fill in this gap so Aurora can seamlessly hold on to a game's authored normals. A game using Aurora can provide this normal buffer for graphics mods to utilize rather than needing to reconstruct scene normals from the depth buffer. Alongside this PR will be a PR for Dusklight, the PC port of Twilight Princess utilizing Aurora. Dusklight will include a copy of the normal buffer with its gfx service, which was also advised by Encounter. I've verified the effectiveness of this PR using the demo AO mod for Dusklight as well as another AO mod of my own. I cannot submit the PR for Dusklight until this PR is merged, should it be accepted. Importantly, unless a consumer sets this normal buffer config, this costs nothing. - automata

Below is a more formal/technical description from Claude without edits:

Fills in the `Normal` colour attachment semantic reserved by the RenderTargetLayout refactor. When
`AuroraConfig::normalBuffer` is set, the scene pass gains a second colour attachment holding the
authored view-space vertex normal of whichever draw established the depth at each pixel, and
`resolve_pass` can snapshot it alongside colour and depth. With the flag unset nothing changes: the
layout is identical, no texture is allocated, and generated shaders are byte-for-byte the same.

The attachment is `RGB10A2Unorm`, encoded `xyz * 0.5 + 0.5`. Ten bits per axis avoids the banding an
8-bit encoding produces on low-curvature surfaces at the same four bytes, and the remaining two carry
a validity flag: alpha is 1 where the normal is usable and 0 where the draw supplied no normal
attribute, nothing wrote depth, or interpolation cancelled the normal to zero. Reporting the
degenerate case rather than storing a zero vector keeps consumers from normalising one.

Coverage follows depth writes. The second colour target's write mask is `All` only when
`depthCompare && depthUpdate`, so a pixel's normal belongs to the draw that owns its depth and later
blended geometry leaves it alone. For the same reason the attachment clears with depth rather than
with colour in `resolve_pass_into`. The result is that the normal and depth buffers always describe
the same surface — particle billboards and the game's projected shadow quads write neither and cannot
contaminate it.

The stored direction keeps the sign the game gave it. `@builtin(front_facing)` is deliberately not
used to reorient it: it cannot distinguish a reverse pass that supplies its own normals from a draw
whose winding was flipped by a negative-determinant modelview, and getting that wrong inverts whole
objects. This is documented on the enumerator, since a consumer applying the "flip towards the
camera" guard that depth reconstruction needs will seam flat ground.

Shader and pipeline selection hang off one bit in `ShaderConfig`, taken from the existing `pad1`
reserve next to `fogRangeEnabled`. `PipelineConfig` embeds `ShaderConfig`, so pipeline cache identity
follows without a version bump, and a cache written before this change decodes the bit as zero —
correct when the attachment is absent.

Compatibility mode cannot support it: it requires every colour target of a pipeline to share one
write mask and blend state, which the normal target cannot do. `normalBuffer` is therefore silently
ignored without core features, so consumers should look for `ColorAttachmentSemantic::Normal` in the
scene layout rather than assume it is present. Offscreen passes carry no normal attachment.

Known limitation: under MSAA the normal snapshot reads the box-filtered resolve while the depth
snapshot takes sample 0, so at silhouette edges the two disagree and the 2-bit alpha resolves partial
coverage to a fractional value. Nothing in-tree enables MSAA today; fixing it properly means
resolving sample 0 of the normal target through a shader the way `snapshot_depth` does. I've left
that out rather than guess at a design for a path nothing exercises.

`gfx_recording_tests` gains coverage for the layout gaining the attachment, offscreen passes omitting
it, and the clear following depth rather than colour.

-

I explicitly referenced Claude and directing a coding agent above, but for full transparency the programming was carried out via LLM. I personally looked through most changes as they happened, and I did catch potential issues that were resolved. I don’t have programming experience outside of some Python, so I can’t claim to have a deep technical understanding of the code, just a laymen’s/plain English understanding.