### PR TITLE
Conditionally enable exceptions

### DIFF
--- a/lib/gfx/texture_replacement.cpp
+++ b/lib/gfx/texture_replacement.cpp
@@ -567,9 +567,13 @@ bool guarded_virtual_read(const std::shared_ptr<VirtualReadState>& state, const 
   }
 
   bool read = false;
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   try {
+#endif
     read = source.read(source.userData, path, outBytes);
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   } catch (...) { Log.warn("texture_replacement: virtual read callback threw for {}", path); }
+#endif
   bool cancelled = false;
   {
     std::lock_guard lock{state->mutex};

--- a/lib/io.cpp
+++ b/lib/io.cpp
@@ -105,7 +105,9 @@ bool write_at(SDL_IOStream* stream, uint64_t offset, const void* src, size_t siz
 }
 
 std::optional<std::vector<uint8_t>> read_file(const std::filesystem::path& path) noexcept {
-  try {
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
+   try {
+#endif
     auto stream = open_file(path, "rb");
     if (!stream) {
       return std::nullopt;
@@ -124,24 +126,32 @@ std::optional<std::vector<uint8_t>> read_file(const std::filesystem::path& path)
       return std::nullopt;
     }
     return data;
-  } catch (const std::exception& error) {
-    SDL_SetError("Failed to read file: %s", error.what());
-    return std::nullopt;
-  }
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
+   } catch (const std::exception& error) {
+     SDL_SetError("Failed to read file: %s", error.what());
+     return std::nullopt;
+   }
+#endif
 }
 
 bool create_directories(const std::filesystem::path& path) noexcept {
   if (path.empty()) {
     return true;
   }
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   try {
+#endif
     const auto pathString = fs_path_to_string(path);
     return SDL_CreateDirectory(pathString.c_str());
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   } catch (const std::exception& error) { return SDL_SetError("Failed to encode directory path: %s", error.what()); }
+#endif
 }
 
 bool write_file(const std::filesystem::path& path, std::span<const uint8_t> data) noexcept {
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   try {
+#endif
     if (!io::create_directories(path.parent_path())) {
       return false;
     }
@@ -157,7 +167,9 @@ bool write_file(const std::filesystem::path& path, std::span<const uint8_t> data
       restore_error(writeError);
     }
     return written && closed;
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   } catch (const std::exception& error) { return SDL_SetError("Failed to write file: %s", error.what()); }
+#endif
 }
 
 AtomicFileWriter::AtomicFileWriter(Stream stream, std::string temporaryPath, std::string targetPath) noexcept
@@ -224,7 +236,9 @@ bool AtomicFileWriter::commit() noexcept {
 }
 
 AtomicFileWriter open_atomic_file(const std::filesystem::path& path, AtomicFileMode mode) noexcept {
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
   try {
+#endif
     if (!io::create_directories(path.parent_path())) {
       return {};
     }
@@ -265,10 +279,12 @@ AtomicFileWriter open_atomic_file(const std::filesystem::path& path, AtomicFileM
     }
 
     return AtomicFileWriter{std::move(stream), std::move(temporaryPath), targetPath};
-  } catch (const std::exception& error) {
-    SDL_SetError("Failed to open atomic file: %s", error.what());
-    return {};
-  }
+#if defined(__cpp_exceptions) || defined(_CPPUNWIND)
+   } catch (const std::exception& error) {
+     SDL_SetError("Failed to open atomic file: %s", error.what());
+     return {};
+   }
+#endif
 }
 
 bool write_file_atomic(const std::filesystem::path& path, std::span<const uint8_t> data) noexcept {


### PR DESCRIPTION
This allows projects that disable exceptions to statically build and link aurora.

Exceptions are only used in 5 locations and in ways that can be easily worked around. Note that this *only* conditionally enables them, it does not handle the error path, that will have to be discussed and handled separately as I didn't want to make assumptions on the failure paths